### PR TITLE
Fix not-match cases for MatchError

### DIFF
--- a/matchers/match_error_matcher.go
+++ b/matchers/match_error_matcher.go
@@ -25,7 +25,7 @@ func (matcher *MatchErrorMatcher) Match(actual interface{}) (success bool, messa
 		if reflect.DeepEqual(actualErr.Error(), matcher.Expected) {
 			return true, format.Message(actual, "not to match error", matcher.Expected), nil
 		} else {
-			return true, format.Message(actual, "to match error", matcher.Expected), nil
+			return false, format.Message(actual, "to match error", matcher.Expected), nil
 		}
 	}
 
@@ -33,7 +33,7 @@ func (matcher *MatchErrorMatcher) Match(actual interface{}) (success bool, messa
 		if reflect.DeepEqual(actualErr, matcher.Expected) {
 			return true, format.Message(actual, "not to match error", matcher.Expected), nil
 		} else {
-			return true, format.Message(actual, "to match error", matcher.Expected), nil
+			return false, format.Message(actual, "to match error", matcher.Expected), nil
 		}
 	}
 

--- a/matchers/match_error_matcher_test.go
+++ b/matchers/match_error_matcher_test.go
@@ -23,6 +23,8 @@ var _ = Describe("MatchErrorMatcher", func() {
 			customErr := CustomError{}
 
 			Ω(err).Should(MatchError(errors.New("an error")))
+			Ω(err).ShouldNot(MatchError(errors.New("another error")))
+
 			Ω(fmtErr).Should(MatchError(errors.New("an error")))
 			Ω(customErr).Should(MatchError(CustomError{}))
 		})
@@ -33,6 +35,8 @@ var _ = Describe("MatchErrorMatcher", func() {
 			customErr := CustomError{}
 
 			Ω(err).Should(MatchError("an error"))
+			Ω(err).ShouldNot(MatchError("another error"))
+
 			Ω(fmtErr).Should(MatchError("an error"))
 			Ω(customErr).Should(MatchError("an error"))
 		})


### PR DESCRIPTION
Currently MatchError doesn't work for not-mached cases.
