### PR TITLE
Make gexec.Build work on windows

### DIFF
--- a/gexec/build.go
+++ b/gexec/build.go
@@ -6,7 +6,9 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
+	"runtime"
 )
 
 var tmpDir string
@@ -34,7 +36,10 @@ func BuildIn(gopath string, packagePath string, args ...string) (compiledPath st
 		return "", errors.New("$GOPATH not provided when building " + packagePath)
 	}
 
-	executable := filepath.Join(tmpDir, filepath.Base(packagePath))
+	executable := filepath.Join(tmpDir, path.Base(packagePath))
+	if runtime.GOOS == "windows" {
+		executable = executable + ".exe"
+	}
 
 	cmdArgs := append([]string{"build"}, args...)
 	cmdArgs = append(cmdArgs, "-o", executable, packagePath)


### PR DESCRIPTION
- Determine executable path from import path using
  path.Base, not filepath.Base
- Append .exe to executable name on windows

Signed-off-by: Brannon Jones brannon.jones@tier3.com
