### PR TITLE
Add string prefix and suffix matchers

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -161,6 +161,26 @@ func ContainSubstring(substr string, args ...interface{}) types.GomegaMatcher {
 	}
 }
 
+//HavePrefix succeeds if actual is a string or stringer that contains the
+//passed-in string as a prefix.  Optional arguments can be provided to construct
+//via fmt.Sprintf().
+func HavePrefix(prefix string, args ...interface{}) types.GomegaMatcher {
+	return &matchers.HavePrefixMatcher{
+		Prefix: prefix,
+		Args:   args,
+	}
+}
+
+//HaveSuffix succeeds if actual is a string or stringer that contains the
+//passed-in string as a suffix.  Optional arguments can be provided to construct
+//via fmt.Sprintf().
+func HaveSuffix(suffix string, args ...interface{}) types.GomegaMatcher {
+	return &matchers.HaveSuffixMatcher{
+		Suffix: suffix,
+		Args:   args,
+	}
+}
+
 //MatchJSON succeeds if actual is a string or stringer of JSON that matches
 //the expected JSON.  The JSONs are decoded and the resulting objects are compared via
 //reflect.DeepEqual so things like key-ordering and whitespace shouldn't matter.

--- a/matchers/have_prefix_matcher.go
+++ b/matchers/have_prefix_matcher.go
@@ -1,0 +1,35 @@
+package matchers
+
+import (
+	"fmt"
+	"github.com/onsi/gomega/format"
+)
+
+type HavePrefixMatcher struct {
+	Prefix string
+	Args   []interface{}
+}
+
+func (matcher *HavePrefixMatcher) Match(actual interface{}) (success bool, err error) {
+	actualString, ok := toString(actual)
+	if !ok {
+		return false, fmt.Errorf("HavePrefix matcher requires a string or stringer.  Got:\n%s", format.Object(actual, 1))
+	}
+	prefix := matcher.prefix()
+	return len(actualString) >= len(prefix) && actualString[0:len(prefix)] == prefix, nil
+}
+
+func (matcher *HavePrefixMatcher) prefix() string {
+	if len(matcher.Args) > 0 {
+		return fmt.Sprintf(matcher.Prefix, matcher.Args...)
+	}
+	return matcher.Prefix
+}
+
+func (matcher *HavePrefixMatcher) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "to have prefix", matcher.prefix())
+}
+
+func (matcher *HavePrefixMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to have prefix", matcher.prefix())
+}

--- a/matchers/have_prefix_matcher_test.go
+++ b/matchers/have_prefix_matcher_test.go
@@ -1,0 +1,36 @@
+package matchers_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/matchers"
+)
+
+var _ = Describe("HavePrefixMatcher", func() {
+	Context("when actual is a string", func() {
+		It("should match a string prefix", func() {
+			Ω("Ab").Should(HavePrefix("A"))
+			Ω("A").ShouldNot(HavePrefix("Ab"))
+		})
+	})
+
+	Context("when the matcher is called with multiple arguments", func() {
+		It("should pass the string and arguments to sprintf", func() {
+			Ω("C3PO").Should(HavePrefix("C%dP", 3))
+		})
+	})
+
+	Context("when actual is a stringer", func() {
+		It("should call the stringer and match against the returned string", func() {
+			Ω(&myStringer{a: "Ab"}).Should(HavePrefix("A"))
+		})
+	})
+
+	Context("when actual is neither a string nor a stringer", func() {
+		It("should error", func() {
+			success, err := (&HavePrefixMatcher{Prefix: "2"}).Match(2)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+		})
+	})
+})

--- a/matchers/have_suffix_matcher.go
+++ b/matchers/have_suffix_matcher.go
@@ -1,0 +1,35 @@
+package matchers
+
+import (
+	"fmt"
+	"github.com/onsi/gomega/format"
+)
+
+type HaveSuffixMatcher struct {
+	Suffix string
+	Args   []interface{}
+}
+
+func (matcher *HaveSuffixMatcher) Match(actual interface{}) (success bool, err error) {
+	actualString, ok := toString(actual)
+	if !ok {
+		return false, fmt.Errorf("HaveSuffix matcher requires a string or stringer.  Got:\n%s", format.Object(actual, 1))
+	}
+	suffix := matcher.suffix()
+	return len(actualString) >= len(suffix) && actualString[len(actualString) - len(suffix):] == suffix, nil
+}
+
+func (matcher *HaveSuffixMatcher) suffix() string {
+	if len(matcher.Args) > 0 {
+		return fmt.Sprintf(matcher.Suffix, matcher.Args...)
+	}
+	return matcher.Suffix
+}
+
+func (matcher *HaveSuffixMatcher) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "to have suffix", matcher.suffix())
+}
+
+func (matcher *HaveSuffixMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to have suffix", matcher.suffix())
+}

--- a/matchers/have_suffix_matcher_test.go
+++ b/matchers/have_suffix_matcher_test.go
@@ -1,0 +1,36 @@
+package matchers_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/matchers"
+)
+
+var _ = Describe("HaveSuffixMatcher", func() {
+	Context("when actual is a string", func() {
+		It("should match a string suffix", func() {
+			Ω("Ab").Should(HaveSuffix("b"))
+			Ω("A").ShouldNot(HaveSuffix("Ab"))
+		})
+	})
+
+	Context("when the matcher is called with multiple arguments", func() {
+		It("should pass the string and arguments to sprintf", func() {
+			Ω("C3PO").Should(HaveSuffix("%dPO", 3))
+		})
+	})
+
+	Context("when actual is a stringer", func() {
+		It("should call the stringer and match against the returned string", func() {
+			Ω(&myStringer{a: "Ab"}).Should(HaveSuffix("b"))
+		})
+	})
+
+	Context("when actual is neither a string nor a stringer", func() {
+		It("should error", func() {
+			success, err := (&HaveSuffixMatcher{Suffix: "2"}).Match(2)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
Regular expression matchers would suffice, but regular expressions are always
potential sources of problems.

The implementation could have reused the regular expression matcher, but by
implementing each matcher in its own right, the code structure is simpler and
diagnostic messages are worded in terms of prefixes and suffices. Ease of use
is more important than the cost of a little extra code.

Documentation branch to be updated in a separate commit.
