### PR TITLE
Fix "Working with Strings and JSON" sidebar links

### DIFF
--- a/_includes/gomega_sidebar.html
+++ b/_includes/gomega_sidebar.html
@@ -118,15 +118,21 @@
             </li>
 
             <li> 
-                <a href="#working-with-channels">Working with Strings and JSON</a>
+                <a href="#working-with-strings-and-json">Working with Strings and JSON</a>
                 <ul class="nav">
                     <li>
                         <a href="#containsubstringsubstr-string-args-interface"><code>ContainSubstring(...)</code></a>
                     </li>
                     <li>
+                        <a href="#haveprefixprefix-string-args-interfacee"><code>HavePrefix(...)</code></a>
+                    </li>
+                    <li>
+                        <a href="#havesuffixsuffix-string-args-interface"><code>HaveSuffix(...)</code></a>
+                    </li>
+                    <li>
                         <a href="#matchregexpregexp-string-args-interface"><code>MatchRegexp(...)</code></a>
                     </li>
-                       <li>
+                    <li>
                         <a href="#matchjsonjson-interface"><code>MatchJSON(...)</code></a>
                     </li>
                 </ul>


### PR DESCRIPTION
Was linking to "Working with channels", also missing 2 of the methods.
