### PR TITLE
prefix writer: simplify, preserve trailing \n

### DIFF
--- a/gexec/prefixed_writer.go
+++ b/gexec/prefixed_writer.go
@@ -1,7 +1,6 @@
 package gexec
 
 import (
-	"bytes"
 	"io"
 	"sync"
 )
@@ -14,19 +13,18 @@ session by passing in a PrefixedWriter:
 gexec.Start(cmd, NewPrefixedWriter("[my-cmd] ", GinkgoWriter), NewPrefixedWriter("[my-cmd] ", GinkgoWriter))
 */
 type PrefixedWriter struct {
-	prefix       []byte
-	writer       io.Writer
-	lock         *sync.Mutex
-	isNewLine    bool
-	isFirstWrite bool
+	prefix        []byte
+	writer        io.Writer
+	lock          *sync.Mutex
+	atStartOfLine bool
 }
 
 func NewPrefixedWriter(prefix string, writer io.Writer) *PrefixedWriter {
 	return &PrefixedWriter{
-		prefix:       []byte(prefix),
-		writer:       writer,
-		lock:         &sync.Mutex{},
-		isFirstWrite: true,
+		prefix:        []byte(prefix),
+		writer:        writer,
+		lock:          &sync.Mutex{},
+		atStartOfLine: true,
 	}
 }
 
@@ -34,46 +32,21 @@ func (w *PrefixedWriter) Write(b []byte) (int, error) {
 	w.lock.Lock()
 	defer w.lock.Unlock()
 
-	newLine := []byte("\n")
-	segments := bytes.Split(b, newLine)
+	toWrite := []byte{}
 
-	if len(segments) != 0 {
-		toWrite := []byte{}
-		if w.isFirstWrite {
+	for _, c := range b {
+		if w.atStartOfLine {
 			toWrite = append(toWrite, w.prefix...)
-			toWrite = append(toWrite, segments[0]...)
-			w.isFirstWrite = false
-		} else if w.isNewLine {
-			toWrite = append(toWrite, newLine...)
-			toWrite = append(toWrite, w.prefix...)
-			toWrite = append(toWrite, segments[0]...)
-		} else {
-			toWrite = append(toWrite, segments[0]...)
 		}
 
-		for i := 1; i < len(segments)-1; i++ {
-			toWrite = append(toWrite, newLine...)
-			toWrite = append(toWrite, w.prefix...)
-			toWrite = append(toWrite, segments[i]...)
-		}
+		toWrite = append(toWrite, c)
 
-		if len(segments) > 1 {
-			lastSegment := segments[len(segments)-1]
+		w.atStartOfLine = c == '\n'
+	}
 
-			if len(lastSegment) == 0 {
-				w.isNewLine = true
-			} else {
-				toWrite = append(toWrite, newLine...)
-				toWrite = append(toWrite, w.prefix...)
-				toWrite = append(toWrite, lastSegment...)
-				w.isNewLine = false
-			}
-		}
-
-		_, err := w.writer.Write(toWrite)
-		if err != nil {
-			return 0, err
-		}
+	_, err := w.writer.Write(toWrite)
+	if err != nil {
+		return 0, err
 	}
 
 	return len(b), nil

--- a/gexec/prefixed_writer_test.go
+++ b/gexec/prefixed_writer_test.go
@@ -2,6 +2,7 @@ package gexec_test
 
 import (
 	"bytes"
+
 	. "github.com/onsi/gomega/gexec"
 
 	. "github.com/onsi/ginkgo"
@@ -36,6 +37,7 @@ var _ = Describe("PrefixedWriter", func() {
 [p]nopqrs
 [p]tuv
 [p]wxyz
-[p]`))
+[p]
+`))
 	})
 })


### PR DESCRIPTION
not sure if i'm missing any of the subtleties of the previous code. noticed it was lopping off trailing linebreaks and munging things together awkwardly some times. updated the test to preserve trailing linebreak and ended up rewriting the algorithm.

this is what I was seeing before:

http://cl.ly/image/0V2M0y233V3h
