### PR TITLE
Return prettyprinted JSON strings for errors.

### DIFF
--- a/matchers/match_json_matcher.go
+++ b/matchers/match_json_matcher.go
@@ -57,5 +57,5 @@ func (matcher *MatchJSONMatcher) prettyPrint(actual interface{}) (actualFormatte
 		return "", "", err
 	}
 
-	return actualString, expectedString, nil
+	return abuf.String(), ebuf.String(), nil
 }


### PR DESCRIPTION
This makes gomega pretty print both the actual and expected strings on an error.  I find that it's easier to see the differences this way.