### PR TITLE
file based matchers

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -250,7 +250,6 @@ func ContainElement(element interface{}) types.GomegaMatcher {
 //    Ω([]string{"Foo", "FooBar"}).Should(ConsistOf([]string{"FooBar", "Foo"}))
 //
 //Note that Go's type system does not allow you to write this as ConsistOf([]string{"FooBar", "Foo"}...) as []string and []interface{} are different types - hence the need for this special rule.
-
 func ConsistOf(elements ...interface{}) types.GomegaMatcher {
 	return &matchers.ConsistOfMatcher{
 		Elements: elements,
@@ -325,4 +324,16 @@ func BeAssignableToTypeOf(expected interface{}) types.GomegaMatcher {
 //Actual must be a function that takes no arguments and returns no results.
 func Panic() types.GomegaMatcher {
 	return &matchers.PanicMatcher{}
+}
+
+//BeAnExistingFile succeeds if a file exists.
+//Actual must be a string representing the abs path to the file being checked.
+func BeAnExistingFile() types.GomegaMatcher {
+	return &matchers.BeAnExistingFileMatcher{}
+}
+
+//BeARegularFile succeeds iff a file exists and is a regular file.
+//Actual must be a string representing the abs path to the file being checked.
+func BeARegularFile() types.GomegaMatcher {
+	return &matchers.BeARegularFileMatcher{}
 }

--- a/matchers/be_a_regular_file.go
+++ b/matchers/be_a_regular_file.go
@@ -1,0 +1,54 @@
+package matchers
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/onsi/gomega/format"
+)
+
+type notARegularFileError struct {
+	os.FileInfo
+}
+
+func (t notARegularFileError) Error() string {
+	fileInfo := os.FileInfo(t)
+	switch {
+	case fileInfo.IsDir():
+		return "file is a directory"
+	default:
+		return fmt.Sprintf("file mode is: %s", fileInfo.Mode().String())
+	}
+}
+
+type BeARegularFileMatcher struct {
+	expected interface{}
+	err      error
+}
+
+func (matcher *BeARegularFileMatcher) Match(actual interface{}) (success bool, err error) {
+	actualFilename, ok := actual.(string)
+	if !ok {
+		return false, fmt.Errorf("FileExistsMatcher matcher expects a file path")
+	}
+
+	fileInfo, err := os.Stat(actualFilename)
+	if err != nil {
+		matcher.err = err
+		return false, nil
+	}
+
+	if !fileInfo.Mode().IsRegular() {
+		matcher.err = notARegularFileError{fileInfo}
+		return false, nil
+	}
+	return true, nil
+}
+
+func (matcher *BeARegularFileMatcher) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, fmt.Sprintf("to be a regular file: %s", matcher.err))
+}
+
+func (matcher *BeARegularFileMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, fmt.Sprintf("not be a regular file"))
+}

--- a/matchers/be_a_regular_file_test.go
+++ b/matchers/be_a_regular_file_test.go
@@ -1,0 +1,40 @@
+package matchers_test
+
+import (
+	"io/ioutil"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/matchers"
+)
+
+var _ = Describe("BeARegularFileMatcher", func() {
+	Context("when passed a string", func() {
+		It("should do the right thing", func() {
+			Ω("/dne/test").ShouldNot(BeARegularFile())
+
+			tmpFile, err := ioutil.TempFile("", "gomega-test-tempfile")
+			Ω(err).ShouldNot(HaveOccurred())
+			defer os.Remove(tmpFile.Name())
+			Ω(tmpFile.Name()).Should(BeARegularFile())
+
+			tmpDir, err := ioutil.TempDir("", "gomega-test-tempdir")
+			Ω(err).ShouldNot(HaveOccurred())
+			defer os.Remove(tmpDir)
+			Ω(tmpDir).ShouldNot(BeARegularFile())
+		})
+	})
+
+	Context("when passed something else", func() {
+		It("should error", func() {
+			success, err := (&BeARegularFileMatcher{}).Match(nil)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+
+			success, err = (&BeARegularFileMatcher{}).Match(true)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+		})
+	})
+})

--- a/matchers/be_an_existing_file.go
+++ b/matchers/be_an_existing_file.go
@@ -1,0 +1,38 @@
+package matchers
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/onsi/gomega/format"
+)
+
+type BeAnExistingFileMatcher struct {
+	expected interface{}
+}
+
+func (matcher *BeAnExistingFileMatcher) Match(actual interface{}) (success bool, err error) {
+	actualFilename, ok := actual.(string)
+	if !ok {
+		return false, fmt.Errorf("FileExistsMatcher matcher expects a file path")
+	}
+
+	if _, err = os.Stat(actualFilename); err != nil {
+		switch {
+		case os.IsNotExist(err):
+			return false, nil
+		default:
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+func (matcher *BeAnExistingFileMatcher) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, fmt.Sprintf("to exist"))
+}
+
+func (matcher *BeAnExistingFileMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, fmt.Sprintf("not to exist"))
+}

--- a/matchers/be_an_existing_file_test.go
+++ b/matchers/be_an_existing_file_test.go
@@ -1,0 +1,40 @@
+package matchers_test
+
+import (
+	"io/ioutil"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/matchers"
+)
+
+var _ = Describe("BeAnExistingFileMatcher", func() {
+	Context("when passed a string", func() {
+		It("should do the right thing", func() {
+			Ω("/dne/test").ShouldNot(BeAnExistingFile())
+
+			tmpFile, err := ioutil.TempFile("", "gomega-test-tempfile")
+			Ω(err).ShouldNot(HaveOccurred())
+			defer os.Remove(tmpFile.Name())
+			Ω(tmpFile.Name()).Should(BeAnExistingFile())
+
+			tmpDir, err := ioutil.TempDir("", "gomega-test-tempdir")
+			Ω(err).ShouldNot(HaveOccurred())
+			defer os.Remove(tmpDir)
+			Ω(tmpDir).Should(BeAnExistingFile())
+		})
+	})
+
+	Context("when passed something else", func() {
+		It("should error", func() {
+			success, err := (&BeAnExistingFileMatcher{}).Match(nil)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+
+			success, err = (&BeAnExistingFileMatcher{}).Match(true)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
Adds the following Matchers:
- BeAnExistingFile (succeeds for any type of file if it exists, regular, sym, directory, socket, etc)
- BeARegularFile (succeeds only for regular files)

Other possible matchers that could be created:
- BeADirectory
- BeASymlink (compatability probably is an issue, i.e. unix/darwin only)
- BeASocket (compatability probably is an issue, i.e. unix/darwin only)