### PR TITLE
Make usage of Succeed matcher slightly clearer

### DIFF
--- a/index.md
+++ b/index.md
@@ -397,7 +397,7 @@ succeeds if `ACTUAL` is `nil`.  The intended usage is
 
     Ω(FUNCTION()).Should(Succeed())
 
-where `FUNCTION()` is a function call that returns a *single* error-type.  See [Handling Errors](#handling-errors) for a more detailed discussion.
+where `FUNCTION()` is a function call that returns an error-type as its *first or only* return value.  See [Handling Errors](#handling-errors) for a more detailed discussion.
 
 #### MatchError(expected interface{})
 


### PR DESCRIPTION
A couple of times now I've heard people asking about exactly how this works, and each time I've taken a multi step trip through the docs, ending up in the `Handling Errors` section where I learn that matchers are always passed the first parameter to `Expect` or `Ω`.

I think this change would make that lookup a single step process, and is a little bit clearer.