### PR TITLE
Can use nil pointers that conform to error interface

### DIFF
--- a/matchers/have_occurred_matcher.go
+++ b/matchers/have_occurred_matcher.go
@@ -9,7 +9,7 @@ type HaveOccurredMatcher struct {
 }
 
 func (matcher *HaveOccurredMatcher) Match(actual interface{}) (success bool, err error) {
-	if actual == nil {
+	if isNil(actual) {
 		return false, nil
 	}
 

--- a/matchers/have_occurred_matcher_test.go
+++ b/matchers/have_occurred_matcher_test.go
@@ -7,6 +7,14 @@ import (
 	. "github.com/onsi/gomega/matchers"
 )
 
+type CustomErr struct {
+	msg string
+}
+
+func (e *CustomErr) Error() string {
+	return e.msg
+}
+
 var _ = Describe("HaveOccurred", func() {
 	It("should succeed if matching an error", func() {
 		Ω(errors.New("Foo")).Should(HaveOccurred())
@@ -24,5 +32,15 @@ var _ = Describe("HaveOccurred", func() {
 		success, err = (&HaveOccurredMatcher{}).Match("")
 		Ω(success).Should(BeFalse())
 		Ω(err).Should(HaveOccurred())
+	})
+
+	It("should succeed with pointer types that conform to error interface", func() {
+		err := &CustomErr{"ohai"}
+		Ω(err).Should(HaveOccurred())
+	})
+
+	It("should not succeed with nil pointers to types that conform to error interface", func() {
+		var err *CustomErr = nil
+		Ω(err).ShouldNot(HaveOccurred())
 	})
 })


### PR DESCRIPTION
Hi Onsi,

We have found that it was not possible to use custom error types in negative assertions about errors. The problem can be observed using the example code:

```
var err *SomeCustomErrorType = nil
Ω(err).ShouldNot(HaveOccurred()) // panics
```

Thanks,
Craig Furman & George Lestaris