### PR TITLE
Set Content-Type to application/json in RespondWithJSON* methods

### DIFF
--- a/ghttp/handlers.go
+++ b/ghttp/handlers.go
@@ -183,7 +183,15 @@ Also, RespondWithJSONEncoded can be given an optional http.Header.  The headers 
 func RespondWithJSONEncoded(statusCode int, object interface{}, optionalHeader ...http.Header) http.HandlerFunc {
 	data, err := json.Marshal(object)
 	Ω(err).ShouldNot(HaveOccurred())
-	return RespondWith(statusCode, string(data), optionalHeader...)
+
+	var headers http.Header
+	if len(optionalHeader) == 1 {
+		headers = optionalHeader[0]
+	} else {
+		headers = make(http.Header)
+	}
+	headers["Content-Type"] = []string{"application/json"}
+	return RespondWith(statusCode, string(data), headers)
 }
 
 /*
@@ -200,9 +208,14 @@ func RespondWithJSONEncodedPtr(statusCode *int, object interface{}, optionalHead
 	return func(w http.ResponseWriter, req *http.Request) {
 		data, err := json.Marshal(object)
 		Ω(err).ShouldNot(HaveOccurred())
+		var headers http.Header
 		if len(optionalHeader) == 1 {
-			copyHeader(optionalHeader[0], w.Header())
+			headers = optionalHeader[0]
+		} else {
+			headers = make(http.Header)
 		}
+		headers["Content-Type"] = []string{"application/json"}
+		copyHeader(headers, w.Header())
 		w.WriteHeader(*statusCode)
 		w.Write(data)
 	}

--- a/ghttp/handlers.go
+++ b/ghttp/handlers.go
@@ -190,7 +190,9 @@ func RespondWithJSONEncoded(statusCode int, object interface{}, optionalHeader .
 	} else {
 		headers = make(http.Header)
 	}
-	headers["Content-Type"] = []string{"application/json"}
+	if _, found := headers["Content-Type"]; !found {
+		headers["Content-Type"] = []string{"application/json"}
+	}
 	return RespondWith(statusCode, string(data), headers)
 }
 
@@ -214,7 +216,9 @@ func RespondWithJSONEncodedPtr(statusCode *int, object interface{}, optionalHead
 		} else {
 			headers = make(http.Header)
 		}
-		headers["Content-Type"] = []string{"application/json"}
+		if _, found := headers["Content-Type"]; !found {
+			headers["Content-Type"] = []string{"application/json"}
+		}
 		copyHeader(headers, w.Header())
 		w.WriteHeader(*statusCode)
 		w.Write(data)

--- a/ghttp/test_server_test.go
+++ b/ghttp/test_server_test.go
@@ -583,10 +583,15 @@ var _ = Describe("TestServer", func() {
 			})
 
 			Context("when optional headers are set", func() {
+				var headers http.Header
 				BeforeEach(func() {
+					headers = http.Header{"Stuff": []string{"things"}}
+				})
+
+				JustBeforeEach(func() {
 					s.AppendHandlers(CombineHandlers(
 						VerifyRequest("POST", "/foo"),
-						RespondWithJSONEncoded(http.StatusCreated, []int{1, 2, 3}, http.Header{"Stuff": []string{"things"}}),
+						RespondWithJSONEncoded(http.StatusCreated, []int{1, 2, 3}, headers),
 					))
 				})
 
@@ -602,6 +607,19 @@ var _ = Describe("TestServer", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 
 					Ω(resp.Header["Content-Type"]).Should(Equal([]string{"application/json"}))
+				})
+
+				Context("when setting the Content-Type explicitly", func() {
+					BeforeEach(func() {
+						headers["Content-Type"] = []string{"not-json"}
+					})
+
+					It("should use the Content-Type header that was explicitly set", func() {
+						resp, err = http.Post(s.URL()+"/foo", "application/json", nil)
+						Ω(err).ShouldNot(HaveOccurred())
+
+						Ω(resp.Header["Content-Type"]).Should(Equal([]string{"not-json"}))
+					})
 				})
 			})
 		})
@@ -650,12 +668,17 @@ var _ = Describe("TestServer", func() {
 			})
 
 			Context("when optional headers are set", func() {
+				var headers http.Header
 				BeforeEach(func() {
+					headers = http.Header{"Stuff": []string{"things"}}
+				})
+
+				JustBeforeEach(func() {
 					code = http.StatusOK
 					object = testObject{}
 					s.AppendHandlers(CombineHandlers(
 						VerifyRequest("POST", "/foo"),
-						RespondWithJSONEncodedPtr(&code, &object, http.Header{"Stuff": []string{"things"}}),
+						RespondWithJSONEncodedPtr(&code, &object, headers),
 					))
 				})
 
@@ -671,6 +694,19 @@ var _ = Describe("TestServer", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 
 					Ω(resp.Header["Content-Type"]).Should(Equal([]string{"application/json"}))
+				})
+
+				Context("when setting the Content-Type explicitly", func() {
+					BeforeEach(func() {
+						headers["Content-Type"] = []string{"not-json"}
+					})
+
+					It("should use the Content-Type header that was explicitly set", func() {
+						resp, err = http.Post(s.URL()+"/foo", "application/json", nil)
+						Ω(err).ShouldNot(HaveOccurred())
+
+						Ω(resp.Header["Content-Type"]).Should(Equal([]string{"not-json"}))
+					})
 				})
 			})
 		})

--- a/ghttp/test_server_test.go
+++ b/ghttp/test_server_test.go
@@ -555,22 +555,54 @@ var _ = Describe("TestServer", func() {
 		})
 
 		Describe("RespondWithJSON", func() {
-			BeforeEach(func() {
-				s.AppendHandlers(CombineHandlers(
-					VerifyRequest("POST", "/foo"),
-					RespondWithJSONEncoded(http.StatusCreated, []int{1, 2, 3}),
-				))
+			Context("when no optional headers are set", func() {
+				BeforeEach(func() {
+					s.AppendHandlers(CombineHandlers(
+						VerifyRequest("POST", "/foo"),
+						RespondWithJSONEncoded(http.StatusCreated, []int{1, 2, 3}),
+					))
+				})
+
+				It("should return the response", func() {
+					resp, err = http.Post(s.URL()+"/foo", "application/json", nil)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					Ω(resp.StatusCode).Should(Equal(http.StatusCreated))
+
+					body, err := ioutil.ReadAll(resp.Body)
+					Ω(err).ShouldNot(HaveOccurred())
+					Ω(body).Should(MatchJSON("[1,2,3]"))
+				})
+
+				It("should set the Content-Type header to application/json", func() {
+					resp, err = http.Post(s.URL()+"/foo", "application/json", nil)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					Ω(resp.Header["Content-Type"]).Should(Equal([]string{"application/json"}))
+				})
 			})
 
-			It("should return the response", func() {
-				resp, err = http.Post(s.URL()+"/foo", "application/json", nil)
-				Ω(err).ShouldNot(HaveOccurred())
+			Context("when optional headers are set", func() {
+				BeforeEach(func() {
+					s.AppendHandlers(CombineHandlers(
+						VerifyRequest("POST", "/foo"),
+						RespondWithJSONEncoded(http.StatusCreated, []int{1, 2, 3}, http.Header{"Stuff": []string{"things"}}),
+					))
+				})
 
-				Ω(resp.StatusCode).Should(Equal(http.StatusCreated))
+				It("should preserve those headers", func() {
+					resp, err = http.Post(s.URL()+"/foo", "application/json", nil)
+					Ω(err).ShouldNot(HaveOccurred())
 
-				body, err := ioutil.ReadAll(resp.Body)
-				Ω(err).ShouldNot(HaveOccurred())
-				Ω(body).Should(MatchJSON("[1,2,3]"))
+					Ω(resp.Header["Stuff"]).Should(Equal([]string{"things"}))
+				})
+
+				It("should set the Content-Type header to application/json", func() {
+					resp, err = http.Post(s.URL()+"/foo", "application/json", nil)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					Ω(resp.Header["Content-Type"]).Should(Equal([]string{"application/json"}))
+				})
 			})
 		})
 
@@ -582,29 +614,64 @@ var _ = Describe("TestServer", func() {
 
 			var code int
 			var object testObject
-			BeforeEach(func() {
-				code = http.StatusOK
-				object = testObject{}
-				s.AppendHandlers(CombineHandlers(
-					VerifyRequest("POST", "/foo"),
-					RespondWithJSONEncodedPtr(&code, &object),
-				))
+
+			Context("when no optional headers are set", func() {
+				BeforeEach(func() {
+					code = http.StatusOK
+					object = testObject{}
+					s.AppendHandlers(CombineHandlers(
+						VerifyRequest("POST", "/foo"),
+						RespondWithJSONEncodedPtr(&code, &object),
+					))
+				})
+
+				It("should return the response", func() {
+					code = http.StatusCreated
+					object = testObject{
+						Key:   "Jim",
+						Value: "Codes",
+					}
+					resp, err = http.Post(s.URL()+"/foo", "application/json", nil)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					Ω(resp.StatusCode).Should(Equal(http.StatusCreated))
+
+					body, err := ioutil.ReadAll(resp.Body)
+					Ω(err).ShouldNot(HaveOccurred())
+					Ω(body).Should(MatchJSON(`{"Key": "Jim", "Value": "Codes"}`))
+				})
+
+				It("should set the Content-Type header to application/json", func() {
+					resp, err = http.Post(s.URL()+"/foo", "application/json", nil)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					Ω(resp.Header["Content-Type"]).Should(Equal([]string{"application/json"}))
+				})
 			})
 
-			It("should return the response", func() {
-				code = http.StatusCreated
-				object = testObject{
-					Key:   "Jim",
-					Value: "Codes",
-				}
-				resp, err = http.Post(s.URL()+"/foo", "application/json", nil)
-				Ω(err).ShouldNot(HaveOccurred())
+			Context("when optional headers are set", func() {
+				BeforeEach(func() {
+					code = http.StatusOK
+					object = testObject{}
+					s.AppendHandlers(CombineHandlers(
+						VerifyRequest("POST", "/foo"),
+						RespondWithJSONEncodedPtr(&code, &object, http.Header{"Stuff": []string{"things"}}),
+					))
+				})
 
-				Ω(resp.StatusCode).Should(Equal(http.StatusCreated))
+				It("should preserve those headers", func() {
+					resp, err = http.Post(s.URL()+"/foo", "application/json", nil)
+					Ω(err).ShouldNot(HaveOccurred())
 
-				body, err := ioutil.ReadAll(resp.Body)
-				Ω(err).ShouldNot(HaveOccurred())
-				Ω(body).Should(MatchJSON(`{"Key": "Jim", "Value": "Codes"}`))
+					Ω(resp.Header["Stuff"]).Should(Equal([]string{"things"}))
+				})
+
+				It("should set the Content-Type header to application/json", func() {
+					resp, err = http.Post(s.URL()+"/foo", "application/json", nil)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					Ω(resp.Header["Content-Type"]).Should(Equal([]string{"application/json"}))
+				})
 			})
 		})
 	})


### PR DESCRIPTION
RespondWithJSONEncoded and RespondWithJSONEncodedPtr now set the response Content-Type header correctly.