### PR TITLE
Added Implements() matcher to verify value implements a given interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 *.test
 .
+# editor
+.idea
+*.iml

--- a/matchers.go
+++ b/matchers.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/onsi/gomega/matchers"
 	"github.com/onsi/gomega/types"
+	"reflect"
 )
 
 //Equal uses reflect.DeepEqual to compare actual with expected.  Equal is strict about
@@ -318,6 +319,20 @@ func BeAssignableToTypeOf(expected interface{}) types.GomegaMatcher {
 	return &matchers.AssignableToTypeOfMatcher{
 		Expected: expected,
 	}
+}
+
+//Implements succeeds if the actual value implements the given interface.
+//This is different from BeAssignableToTypeOf because it matches an interface rather than a concrete type.
+//Interface can provided as in this example for `error`:
+//   reflect.TypeOf((*error)(nil)).Elem()
+func Implements(interfaceType reflect.Type) types.GomegaMatcher {
+	if interfaceType == nil {
+		panic("nil type passed to Implements")
+	}
+	if interfaceType.Kind() != reflect.Interface {
+		panic("non-interface type passed to Implements")
+	}
+	return &matchers.ImplementsMatcher{InterfaceType: interfaceType}
 }
 
 //Panic succeeds if actual is a function that, when invoked, panics.

--- a/matchers.go
+++ b/matchers.go
@@ -323,8 +323,9 @@ func BeAssignableToTypeOf(expected interface{}) types.GomegaMatcher {
 
 //Implements succeeds if the actual value implements the given interface.
 //This is different from BeAssignableToTypeOf because it matches an interface rather than a concrete type.
-//Interface can provided as in this example for `error`:
-//   reflect.TypeOf((*error)(nil)).Elem()
+//   var errorInterface = reflect.TypeOf((*error)(nil)).Elem()
+//   var actualErr = errors.New("some error")
+//   Ω(actualErr).Should(Implements(errorInterface))
 func Implements(interfaceType reflect.Type) types.GomegaMatcher {
 	if interfaceType == nil {
 		panic("nil type passed to Implements")

--- a/matchers/implements.go
+++ b/matchers/implements.go
@@ -1,0 +1,27 @@
+package matchers
+
+import (
+	"fmt"
+	"github.com/onsi/gomega/format"
+	"reflect"
+)
+
+type ImplementsMatcher struct {
+	InterfaceType reflect.Type
+}
+
+func (m *ImplementsMatcher) Match(actual interface{}) (success bool, err error) {
+	if actual == nil {
+		return false, nil
+	}
+	a := reflect.ValueOf(actual)
+	return a.Type().Implements(m.InterfaceType), nil
+}
+
+func (m *ImplementsMatcher) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, fmt.Sprintf("to implement %s", m.InterfaceType))
+}
+
+func (m *ImplementsMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, fmt.Sprintf("to not implement %s", m.InterfaceType))
+}

--- a/matchers/implements_test.go
+++ b/matchers/implements_test.go
@@ -1,0 +1,55 @@
+package matchers_test
+
+import (
+	"errors"
+	"reflect"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ImplementsMatcherMatcher", func() {
+
+	var errorInterface = reflect.TypeOf((*error)(nil)).Elem()
+
+	Context("when actual implements the given interface", func() {
+		It("matches", func() {
+			Expect(errors.New("hi")).To(Implements(errorInterface))
+		})
+	})
+
+	Context("when actual does not implement the given interface", func() {
+		It("does not match", func() {
+			Expect(nil).ToNot(Implements(errorInterface))
+			Expect("hi").ToNot(Implements(errorInterface))
+		})
+	})
+
+	Context("failure messages", func() {
+		var m = Implements(errorInterface)
+
+		Context("when match fails", func() {
+			It("gives a descriptive message", func() {
+				actual := "hi"
+				Expect(m.Match(actual)).To(BeFalse())
+				Expect(m.FailureMessage(actual)).To(Equal("Expected\n    <string>: hi\nto implement error"))
+			})
+		})
+
+		Context("when match succeeds, but expected it to fail", func() {
+			It("gives a descriptive message", func() {
+				actual := errors.New("hi")
+				Expect(m.Match(actual)).To(BeTrue())
+				Expect(m.NegatedFailureMessage(actual)).To(MatchRegexp(
+					"Expected\n    <*errors.errorString | 0x[^>]+>: {s: \"hi\"}\nto not implement error"))
+			})
+		})
+	})
+
+	Context("Invalid interface provided", func() {
+		It("panics", func() {
+			Expect(func() { Implements(nil) }).To(Panic(), "nil interface type")
+			Expect(func() { Implements(reflect.TypeOf(123)) }).To(Panic(), "not an interface type")
+		})
+	})
+})


### PR DESCRIPTION
- This is different from `BeAssignableToTypeOf()` because it matches an interface rather than a concrete type.