### PR TITLE
Append diff of actual and expected to failure messages.

### DIFF
--- a/format/format_test.go
+++ b/format/format_test.go
@@ -128,9 +128,62 @@ var _ = Describe("Format", func() {
 				Ω(Message(3, "to equal", 4)).Should(Equal("Expected\n    <int>: 3\nto equal\n    <int>: 4"))
 			})
 		})
+
+		Context("with an actual and and expected value of type string", func() {
+			const left = "left"
+			const right = "right"
+			var diff bool
+
+			Context("without diff available", func() {
+				BeforeEach(func() {
+					diff = SupportsDiff
+					SupportsDiff = false
+				})
+
+				AfterEach(func() {
+					SupportsDiff = diff
+				})
+
+				It("should print out an indented formatted representation of both values, and the message", func() {
+					Ω(Message(left, "to equal", right)).Should(Equal("Expected\n    <string>: " + left + "\nto equal\n    <string>: " + right))
+				})
+			})
+
+			Context("with the diff tool available", func() {
+				const fakeOutput = "DIFF CALLED"
+				var doDiff func(string, string) string
+
+				BeforeEach(func() {
+					diff = SupportsDiff
+					SupportsDiff = true
+					doDiff = DoDiff
+					DoDiff = func(left, right string) string { return fakeOutput }
+				})
+
+				AfterEach(func() {
+					SupportsDiff = diff
+					DoDiff = doDiff
+				})
+
+				It("should append a diff of the actual and expected values", func() {
+					Ω(Message(left, "to equal", right)).Should(Equal("Expected\n    <string>: " + left + "\nto equal\n    <string>: " + right + "\n\ndiff:\n" + fakeOutput))
+				})
+			})
+		})
 	})
 
 	Describe("MessageWithDiff", func() {
+		var diff bool
+
+		BeforeEach(func() {
+			diff = SupportsDiff
+			SupportsDiff = false
+		})
+
+		AfterEach(func() {
+			SupportsDiff = diff
+		})
+
 		It("shows the exact point where two long strings differ", func() {
 			stringWithB := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 			stringWithZ := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaazaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/matchers/and_test.go
+++ b/matchers/and_test.go
@@ -3,6 +3,7 @@ package matchers_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	. "github.com/onsi/gomega/matchers"
 	"github.com/onsi/gomega/types"
 )
@@ -23,6 +24,10 @@ var (
 
 // verifyFailureMessage expects the matcher to fail with the given input, and verifies the failure message.
 func verifyFailureMessage(m types.GomegaMatcher, input string, expectedFailureMsgFragment string) {
+	var diff bool
+	diff, format.SupportsDiff = format.SupportsDiff, false
+	defer func() { format.SupportsDiff = diff }()
+
 	Expect(m.Match(input)).To(BeFalse())
 	Expect(m.FailureMessage(input)).To(Equal(
 		"Expected\n    <string>: " + input + "\n" + expectedFailureMsgFragment))

--- a/matchers/equal_matcher_test.go
+++ b/matchers/equal_matcher_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	. "github.com/onsi/gomega/matchers"
 )
 
@@ -48,6 +49,10 @@ var _ = Describe("Equal", func() {
 
 	Describe("failure messages", func() {
 		It("shows the two strings simply when they are short", func() {
+			var diff bool
+			diff, format.SupportsDiff = format.SupportsDiff, false
+			defer func() { format.SupportsDiff = diff }()
+
 			subject := EqualMatcher{Expected: "eric"}
 
 			failureMessage := subject.FailureMessage("tim")
@@ -55,6 +60,10 @@ var _ = Describe("Equal", func() {
 		})
 
 		It("shows the exact point where two long strings differ", func() {
+			var diff bool
+			diff, format.SupportsDiff = format.SupportsDiff, false
+			defer func() { format.SupportsDiff = diff }()
+
 			stringWithB := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 			stringWithZ := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaazaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 


### PR DESCRIPTION
When both actual and expected are strings and the diff tool is available
on the system.

This is not the prettyiest implementation (relies on diff and creates temp files) but
as it turns out implementing an efficient diff algorithm is not that simple ;)
However having a diff printed is the number one feature I am missing from rspec,
it makes finding problems a lot easier in cases the strings are long (e.g. JSON
or XML content).
