### PR TITLE
Add VerifyBody method.

### DIFF
--- a/ghttp/handlers.go
+++ b/ghttp/handlers.go
@@ -90,6 +90,19 @@ func VerifyHeaderKV(key string, values ...string) http.HandlerFunc {
 	return VerifyHeader(http.Header{key: values})
 }
 
+//VerifyBody returns a handler that verifies that the body of the request matches the passed in byte array.
+//It does this using Equal().
+func VerifyBody(expectedBody []byte) http.HandlerFunc {
+	return CombineHandlers(
+		func(w http.ResponseWriter, req *http.Request) {
+			body, err := ioutil.ReadAll(req.Body)
+			req.Body.Close()
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(body).Should(Equal(expectedBody), "Body Mismatch")
+		},
+	)
+}
+
 //VerifyJSON returns a handler that verifies that the body of the request is a valid JSON representation
 //matching the passed in JSON string.  It does this using Gomega's MatchJSON method
 //

--- a/ghttp/test_server_test.go
+++ b/ghttp/test_server_test.go
@@ -456,6 +456,27 @@ var _ = Describe("TestServer", func() {
 			})
 		})
 
+		Describe("VerifyBody", func() {
+			BeforeEach(func() {
+				s.AppendHandlers(CombineHandlers(
+					VerifyRequest("POST", "/foo"),
+					VerifyBody([]byte("some body")),
+				))
+			})
+
+			It("should verify the body", func() {
+				resp, err = http.Post(s.URL()+"/foo", "", bytes.NewReader([]byte("some body")))
+				Ω(err).ShouldNot(HaveOccurred())
+			})
+
+			It("should verify the body", func() {
+				failures := InterceptGomegaFailures(func() {
+					http.Post(s.URL()+"/foo", "", bytes.NewReader([]byte("wrong body")))
+				})
+				Ω(failures).Should(HaveLen(1))
+			})
+		})
+
 		Describe("VerifyJSON", func() {
 			BeforeEach(func() {
 				s.AppendHandlers(CombineHandlers(


### PR DESCRIPTION
- This provides a matcher VerifyBody to ensure the []byte Body of the HTTP request matches the expected.
- This addresses https://github.com/onsi/gomega/issues/110