### PR TITLE
fixed up: Succeed(), HaveOccurred()

### DIFF
--- a/matchers/have_occurred_matcher.go
+++ b/matchers/have_occurred_matcher.go
@@ -10,15 +10,18 @@ type HaveOccurredMatcher struct {
 }
 
 func (matcher *HaveOccurredMatcher) Match(actual interface{}) (success bool, err error) {
-	if isNil(actual) {
+	// is purely nil?
+	if actual == nil {
 		return false, nil
 	}
 
-	if isError(actual) {
-		return true, nil
+	// must be an 'error' type
+	if !isError(actual) {
+		return false, fmt.Errorf("Expected an error-type.  Got:\n%s", format.Object(actual, 1))
 	}
 
-	return false, fmt.Errorf("Expected an error.  Got:\n%s", format.Object(actual, 1))
+	// must be non-nil (or a pointer to a non-nil)
+	return !isNil(actual), nil
 }
 
 func (matcher *HaveOccurredMatcher) FailureMessage(actual interface{}) (message string) {

--- a/matchers/have_occurred_matcher_test.go
+++ b/matchers/have_occurred_matcher_test.go
@@ -34,6 +34,18 @@ var _ = Describe("HaveOccurred", func() {
 		Ω(err).Should(HaveOccurred())
 	})
 
+	It("doesn't support non-error type", func() {
+		success, err := (&HaveOccurredMatcher{}).Match(AnyType{})
+		Ω(success).Should(BeFalse())
+		Ω(err).Should(MatchError("Expected an error-type.  Got:\n    <matchers_test.AnyType>: {}"))
+	})
+
+	It("doesn't support non-error pointer type", func() {
+		success, err := (&HaveOccurredMatcher{}).Match(&AnyType{})
+		Ω(success).Should(BeFalse())
+		Ω(err).Should(MatchError(MatchRegexp(`Expected an error-type.  Got:\n    <*matchers_test.AnyType | 0x[[:xdigit:]]+>: {}`)))
+	})
+
 	It("should succeed with pointer types that conform to error interface", func() {
 		err := &CustomErr{"ohai"}
 		Ω(err).Should(HaveOccurred())

--- a/matchers/succeed_matcher.go
+++ b/matchers/succeed_matcher.go
@@ -10,15 +10,18 @@ type SucceedMatcher struct {
 }
 
 func (matcher *SucceedMatcher) Match(actual interface{}) (success bool, err error) {
+	// is purely nil?
 	if actual == nil {
 		return true, nil
 	}
 
-	if isError(actual) {
-		return false, nil
+	// must be an 'error' type
+	if !isError(actual) {
+		return false, fmt.Errorf("Expected an error-type.  Got:\n%s", format.Object(actual, 1))
 	}
 
-	return false, fmt.Errorf("Expected an error-type.  Got:\n%s", format.Object(actual, 1))
+	// must be nil (or a pointer to a nil)
+	return isNil(actual), nil
 }
 
 func (matcher *SucceedMatcher) FailureMessage(actual interface{}) (message string) {

--- a/matchers/succeed_matcher_test.go
+++ b/matchers/succeed_matcher_test.go
@@ -34,6 +34,29 @@ var _ = Describe("Succeed", func() {
 	It("should not if passed a non-error", func() {
 		success, err := (&SucceedMatcher{}).Match(Invalid())
 		Ω(success).Should(BeFalse())
-		Ω(err).Should(HaveOccurred())
+		Ω(err).Should(MatchError("Expected an error-type.  Got:\n    <*matchers_test.AnyType | 0x0>: nil"))
 	})
+
+	It("doesn't support non-error type", func() {
+		success, err := (&SucceedMatcher{}).Match(AnyType{})
+		Ω(success).Should(BeFalse())
+		Ω(err).Should(MatchError("Expected an error-type.  Got:\n    <matchers_test.AnyType>: {}"))
+	})
+
+	It("doesn't support non-error pointer type", func() {
+		success, err := (&SucceedMatcher{}).Match(&AnyType{})
+		Ω(success).Should(BeFalse())
+		Ω(err).Should(MatchError(MatchRegexp(`Expected an error-type.  Got:\n    <*matchers_test.AnyType | 0x[[:xdigit:]]+>: {}`)))
+	})
+
+	It("should not succeed with pointer types that conform to error interface", func() {
+		err := &CustomErr{"ohai"}
+		Ω(err).ShouldNot(Succeed())
+	})
+
+	It("should succeed with nil pointers to types that conform to error interface", func() {
+		var err *CustomErr = nil
+		Ω(err).Should(Succeed())
+	})
+
 })


### PR DESCRIPTION
- Succeed() would panic if error was a nil pointer, like: `*CustomError`
- Succeed() and HaveOccurred() weren't both rejecting non-error types in all cases.

Added new tests for the above.