### PR TITLE
Allow the ghttp server to be reset

### DIFF
--- a/ghttp/test_server.go
+++ b/ghttp/test_server.go
@@ -349,6 +349,17 @@ func (s *Server) GetHandler(index int) http.HandlerFunc {
 	return s.requestHandlers[index]
 }
 
+func (s *Server) Reset() {
+	s.writeLock.Lock()
+	defer s.writeLock.Unlock()
+
+	s.HTTPTestServer.CloseClientConnections()
+	s.calls = 0
+	s.receivedRequests = nil
+	s.requestHandlers = nil
+	s.routedHandlers = nil
+}
+
 //WrapHandler combines the passed in handler with the handler registered at the passed in index.
 //This is useful, for example, when a server has been set up in a shared context but must be tweaked
 //for a particular test.

--- a/ghttp/test_server_test.go
+++ b/ghttp/test_server_test.go
@@ -31,6 +31,22 @@ var _ = Describe("TestServer", func() {
 		s.Close()
 	})
 
+	Describe("Resetting the server", func() {
+		BeforeEach(func() {
+			s.RouteToHandler("GET", "/", func(w http.ResponseWriter, req *http.Request) {})
+			s.AppendHandlers(func(w http.ResponseWriter, req *http.Request) {})
+			http.Get(s.URL() + "/")
+
+			Ω(s.ReceivedRequests()).Should(HaveLen(1))
+		})
+
+		It("clears all handlers and call counts", func() {
+			s.Reset()
+			Ω(s.ReceivedRequests()).Should(HaveLen(0))
+			Ω(func() {s.GetHandler(0)}).Should(Panic())
+		})
+	})
+
 	Describe("closing client connections", func() {
 		It("closes", func() {
 			s.AppendHandlers(


### PR DESCRIPTION
There are cases were we want to start one http server in BeforeSuite and
reset its handlers & state between tests

Signed-off-by: Topher Bullock <cbullock@pivotal.io>