### PR TITLE
HaveCap matcher

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -217,6 +217,13 @@ func HaveLen(count int) types.GomegaMatcher {
 	}
 }
 
+//HaveCap succeeds if actual has the passed-in capacity.  Actual must be of type array, chan, or slice.
+func HaveCap(count int) types.GomegaMatcher {
+	return &matchers.HaveCapMatcher{
+		Count: count,
+	}
+}
+
 //BeZero succeeds if actual is the zero value for its type or if actual is nil.
 func BeZero() types.GomegaMatcher {
 	return &matchers.BeZeroMatcher{}

--- a/matchers/have_cap_matcher.go
+++ b/matchers/have_cap_matcher.go
@@ -1,0 +1,28 @@
+package matchers
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/format"
+)
+
+type HaveCapMatcher struct {
+	Count int
+}
+
+func (matcher *HaveCapMatcher) Match(actual interface{}) (success bool, err error) {
+	length, ok := capOf(actual)
+	if !ok {
+		return false, fmt.Errorf("HaveCap matcher expects a array/channel/slice.  Got:\n%s", format.Object(actual, 1))
+	}
+
+	return length == matcher.Count, nil
+}
+
+func (matcher *HaveCapMatcher) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected\n%s\nto have capacity %d", format.Object(actual, 1), matcher.Count)
+}
+
+func (matcher *HaveCapMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected\n%s\nnot to have capacity %d", format.Object(actual, 1), matcher.Count)
+}

--- a/matchers/have_cap_matcher_test.go
+++ b/matchers/have_cap_matcher_test.go
@@ -1,0 +1,50 @@
+package matchers_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/matchers"
+)
+
+var _ = Describe("HaveCap", func() {
+	Context("when passed a supported type", func() {
+		It("should do the right thing", func() {
+			Ω([0]int{}).Should(HaveCap(0))
+			Ω([2]int{1}).Should(HaveCap(2))
+
+			Ω([]int{}).Should(HaveCap(0))
+			Ω([]int{1, 2, 3, 4, 5}[:2]).Should(HaveCap(5))
+			Ω(make([]int, 0, 5)).Should(HaveCap(5))
+
+			c := make(chan bool, 3)
+			Ω(c).Should(HaveCap(3))
+			c <- true
+			c <- true
+			Ω(c).Should(HaveCap(3))
+
+			Ω(make(chan bool)).Should(HaveCap(0))
+		})
+	})
+
+	Context("when passed a correctly typed nil", func() {
+		It("should operate succesfully on the passed in value", func() {
+			var nilSlice []int
+			Ω(nilSlice).Should(HaveCap(0))
+
+			var nilChan chan int
+			Ω(nilChan).Should(HaveCap(0))
+		})
+	})
+
+	Context("when passed an unsupported type", func() {
+		It("should error", func() {
+			success, err := (&HaveCapMatcher{Count: 0}).Match(0)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+
+			success, err = (&HaveCapMatcher{Count: 0}).Match(nil)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+		})
+	})
+})

--- a/matchers/type_support.go
+++ b/matchers/type_support.go
@@ -150,6 +150,17 @@ func lengthOf(a interface{}) (int, bool) {
 		return 0, false
 	}
 }
+func capOf(a interface{}) (int, bool) {
+	if a == nil {
+		return 0, false
+	}
+	switch reflect.TypeOf(a).Kind() {
+	case reflect.Array, reflect.Chan, reflect.Slice:
+		return reflect.ValueOf(a).Cap(), true
+	default:
+		return 0, false
+	}
+}
 
 func isNil(a interface{}) bool {
 	if a == nil {


### PR DESCRIPTION
A handy HaveCap matcher, along the same lines as the HaveLen matcher. Works on arrays, channels and slices.