### PR TITLE
Improves MatchJSON error message

### DIFF
--- a/matchers/match_json_matcher.go
+++ b/matchers/match_json_matcher.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/onsi/gomega/format"
 	"reflect"
+
+	"github.com/onsi/gomega/format"
 )
 
 type MatchJSONMatcher struct {
@@ -50,11 +51,11 @@ func (matcher *MatchJSONMatcher) prettyPrint(actual interface{}) (actualFormatte
 	ebuf := new(bytes.Buffer)
 
 	if err := json.Indent(abuf, []byte(actualString), "", "  "); err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("Actual '%s' should be valid JSON, but it is not.\nUnderlying error:%s", actualString, err)
 	}
 
 	if err := json.Indent(ebuf, []byte(expectedString), "", "  "); err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("Expected '%s' should be valid JSON, but it is not.\nUnderlying error:%s", expectedString, err)
 	}
 
 	return abuf.String(), ebuf.String(), nil

--- a/matchers/match_json_matcher_test.go
+++ b/matchers/match_json_matcher_test.go
@@ -25,15 +25,21 @@ var _ = Describe("MatchJSONMatcher", func() {
 		})
 	})
 
-	Context("when either side is not valid JSON", func() {
-		It("should error", func() {
+	Context("when the expected is not valid JSON", func() {
+		It("should error and explain why", func() {
+			success, err := (&MatchJSONMatcher{JSONToMatch: `{}`}).Match(`oops`)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring("Actual 'oops' should be valid JSON"))
+		})
+	})
+
+	Context("when the actual is not valid JSON", func() {
+		It("should error and explain why", func() {
 			success, err := (&MatchJSONMatcher{JSONToMatch: `oops`}).Match(`{}`)
 			Ω(success).Should(BeFalse())
 			Ω(err).Should(HaveOccurred())
-
-			success, err = (&MatchJSONMatcher{JSONToMatch: `{}`}).Match(`oops`)
-			Ω(success).Should(BeFalse())
-			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring("Expected 'oops' should be valid JSON"))
 		})
 	})
 


### PR DESCRIPTION
When one of the actual or expected cannot be parsed as JSON, it would be quite nice to know quickly which one you, kind developer, should be looking at in order to improve and fix your tests.

This commit mostly just adds the words "expected" and "actual" around the error messages, which is hopefully more clear.

@robdimsdale I tried using `json.Marshal` here but it actually yields back a string if you try to marshal a string, which isn't very helpful. My expectation is that `json.Marshal("ruh roh")` which return an error, but it really just yields back `"ruh roh"`.

Wrapping the error with some more precise language seemed like the correct thing to do here, but I'm open to any feedback.

A follow-up to this PR that I would like to do next is to check if the JSON matches, and if not, walk each structure recursively until one field or member of the JSON is found to differ. Is this what you had in mind when you said a "semantically aware, object-level diff", @robdimsdale?