### PR TITLE
Make the error message for expected JSON values having the wrong type…

### DIFF
--- a/matchers/match_json_matcher.go
+++ b/matchers/match_json_matcher.go
@@ -40,11 +40,13 @@ func (matcher *MatchJSONMatcher) NegatedFailureMessage(actual interface{}) (mess
 }
 
 func (matcher *MatchJSONMatcher) prettyPrint(actual interface{}) (actualFormatted, expectedFormatted string, err error) {
-	actualString, aok := toString(actual)
-	expectedString, eok := toString(matcher.JSONToMatch)
-
-	if !(aok && eok) {
-		return "", "", fmt.Errorf("MatchJSONMatcher matcher requires a string or stringer.  Got:\n%s", format.Object(actual, 1))
+	actualString, ok := toString(actual)
+	if !ok {
+		return "", "", fmt.Errorf("MatchJSONMatcher matcher requires a string, stringer, or []byte.  Got actual:\n%s", format.Object(actual, 1))
+	}
+	expectedString, ok := toString(matcher.JSONToMatch)
+	if !ok {
+		return "", "", fmt.Errorf("MatchJSONMatcher matcher requires a string, stringer, or []byte.  Got expected:\n%s", format.Object(matcher.JSONToMatch, 1))
 	}
 
 	abuf := new(bytes.Buffer)

--- a/matchers/match_json_matcher_test.go
+++ b/matchers/match_json_matcher_test.go
@@ -43,23 +43,31 @@ var _ = Describe("MatchJSONMatcher", func() {
 		})
 	})
 
-	Context("when either side is neither a string nor a stringer", func() {
+	Context("when the expected is neither a string nor a stringer or a byte array", func() {
 		It("should error", func() {
-			success, err := (&MatchJSONMatcher{JSONToMatch: "{}"}).Match(2)
+			success, err := (&MatchJSONMatcher{JSONToMatch: 2}).Match("{}")
 			Ω(success).Should(BeFalse())
 			Ω(err).Should(HaveOccurred())
-
-			success, err = (&MatchJSONMatcher{JSONToMatch: 2}).Match("{}")
-			Ω(success).Should(BeFalse())
-			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring("MatchJSONMatcher matcher requires a string, stringer, or []byte.  Got expected:\n    <int>: 2"))
 
 			success, err = (&MatchJSONMatcher{JSONToMatch: nil}).Match("{}")
 			Ω(success).Should(BeFalse())
 			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring("MatchJSONMatcher matcher requires a string, stringer, or []byte.  Got expected:\n    <nil>: nil"))
+		})
+	})
 
-			success, err = (&MatchJSONMatcher{JSONToMatch: 2}).Match(nil)
+	Context("when the actual is neither a string nor a stringer", func() {
+		It("should error", func() {
+			success, err := (&MatchJSONMatcher{JSONToMatch: "{}"}).Match(2)
 			Ω(success).Should(BeFalse())
 			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring("MatchJSONMatcher matcher requires a string, stringer, or []byte.  Got actual:\n    <int>: 2"))
+
+			success, err = (&MatchJSONMatcher{JSONToMatch: "{}"}).Match(nil)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring("MatchJSONMatcher matcher requires a string, stringer, or []byte.  Got actual:\n    <nil>: nil"))
 		})
 	})
 })


### PR DESCRIPTION
… accurate

Before the fix we had a scenario in which

```go
someJSON := `{"description": "this is the actual"}`
Expect(someJSON).To(MatchJSON(map[string]string{"description": "this is the expected"}))
```

Used to fail with the output:

```
      MatchJSONMatcher matcher requires a string or stringer.  Got:
          <string>: {"description": "this is the actual"}
```

This shows the actual, when it is the expected that is of the wrong type.

After the fix, this fails with the output:

```
      MatchJSONMatcher matcher requires a string, stringer, or []byte.  Got expected:
          <map[string]string | len:1>: {
              "description": "this is the expected",
          }
```

Signed-off-by: Tom Anderson <toanderson@pivotal.io>