### PR TITLE
Reset tmpDir in gexec.CleanupBuildArtifacts

### DIFF
--- a/gexec/build.go
+++ b/gexec/build.go
@@ -62,6 +62,7 @@ gexec. In Ginkgo this is typically done in an AfterSuite callback.
 func CleanupBuildArtifacts() {
 	if tmpDir != "" {
 		os.RemoveAll(tmpDir)
+		tmpDir = ""
 	}
 }
 

--- a/gexec/build_test.go
+++ b/gexec/build_test.go
@@ -1,0 +1,37 @@
+package gexec_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe(".Build", func() {
+	var packagePath = "./_fixture/firefly"
+
+	Context("when there have been previous calls to Build", func() {
+		BeforeEach(func() {
+			_, err := gexec.Build(packagePath)
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+
+		It("compiles the specified package", func() {
+			compiledPath, err := gexec.Build(packagePath)
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(compiledPath).Should(BeAnExistingFile())
+		})
+
+		Context("and CleanupBuildArtifacts has been called", func() {
+			BeforeEach(func() {
+				gexec.CleanupBuildArtifacts()
+			})
+
+			It("compiles the specified package", func() {
+				var err error
+				fireflyPath, err = gexec.Build(packagePath)
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(fireflyPath).Should(BeAnExistingFile())
+			})
+		})
+	})
+})


### PR DESCRIPTION
If `tmpDir` is not being reset in `gexec.CleanupBuildArtifacts`, subsequent calls to `gexec.Build` are failing with an `os.PathError`. This is because `gexec.temporaryDirectory` won't recreate the `gexec_artifacts` temp dir if `tmpDir` is set. This is a problem when `Build` and `CleanupBuildArtifacts` are being used in `BeforeEach` and `AfterEach` blocks that are being executed multiple times.