### PR TITLE
Tracking gexec sessions

### DIFF
--- a/gexec/session.go
+++ b/gexec/session.go
@@ -92,6 +92,8 @@ func Start(command *exec.Cmd, outWriter io.Writer, errWriter io.Writer) (*Sessio
 	err := command.Start()
 	if err == nil {
 		go session.monitorForExit(exited)
+		trackedSessionsMutex.Lock()
+		defer trackedSessionsMutex.Unlock()
 		trackedSessions = append(trackedSessions, session)
 	}
 

--- a/gexec/session.go
+++ b/gexec/session.go
@@ -92,9 +92,9 @@ func Start(command *exec.Cmd, outWriter io.Writer, errWriter io.Writer) (*Sessio
 	err := command.Start()
 	if err == nil {
 		go session.monitorForExit(exited)
+		trackedSessions = append(trackedSessions, session)
 	}
 
-	trackedSessions = append(trackedSessions, session)
 	return session, err
 }
 

--- a/gexec/session.go
+++ b/gexec/session.go
@@ -215,13 +215,7 @@ func (s *Session) monitorForExit(exited chan<- struct{}) {
 }
 
 var trackedSessions = []*Session{}
-
-/*
-Resets the sessions tracked by gexec after Run is called.
-*/
-func ResetTrackedSessions() {
-	trackedSessions = []*Session{}
-}
+var trackedSessionsMutex = &sync.Mutex{}
 
 /*
 Kill sends a SIGKILL signal to all the processes started by Run, and waits for them to exit.
@@ -230,6 +224,8 @@ The timeout specified is applied to each process killed.
 If any of the processes already exited, KillAndWait returns silently.
 */
 func KillAndWait(timeout ...interface{}) {
+	trackedSessionsMutex.Lock()
+	defer trackedSessionsMutex.Unlock()
 	for _, session := range trackedSessions {
 		session.Kill().Wait(timeout...)
 	}
@@ -242,6 +238,8 @@ The timeout specified is applied to each process killed.
 If any of the processes already exited, TerminateAndWait returns silently.
 */
 func TerminateAndWait(timeout ...interface{}) {
+	trackedSessionsMutex.Lock()
+	defer trackedSessionsMutex.Unlock()
 	for _, session := range trackedSessions {
 		session.Terminate().Wait(timeout...)
 	}
@@ -254,6 +252,8 @@ It does not wait for the processes to exit.
 If any of the processes already exited, Kill returns silently.
 */
 func Kill() {
+	trackedSessionsMutex.Lock()
+	defer trackedSessionsMutex.Unlock()
 	for _, session := range trackedSessions {
 		session.Kill()
 	}
@@ -266,6 +266,8 @@ It does not wait for the processes to exit.
 If any of the processes already exited, Terminate returns silently.
 */
 func Terminate() {
+	trackedSessionsMutex.Lock()
+	defer trackedSessionsMutex.Unlock()
 	for _, session := range trackedSessions {
 		session.Terminate()
 	}
@@ -278,6 +280,8 @@ It does not wait for the processes to exit.
 If any of the processes already exited, Signal returns silently.
 */
 func Signal(signal os.Signal) {
+	trackedSessionsMutex.Lock()
+	defer trackedSessionsMutex.Unlock()
 	for _, session := range trackedSessions {
 		session.Signal(signal)
 	}
@@ -290,6 +294,8 @@ It does not wait for the processes to exit.
 If any of the processes already exited, Interrupt returns silently.
 */
 func Interrupt() {
+	trackedSessionsMutex.Lock()
+	defer trackedSessionsMutex.Unlock()
 	for _, session := range trackedSessions {
 		session.Interrupt()
 	}

--- a/gexec/session.go
+++ b/gexec/session.go
@@ -229,6 +229,7 @@ func KillAndWait(timeout ...interface{}) {
 	for _, session := range trackedSessions {
 		session.Kill().Wait(timeout...)
 	}
+	trackedSessions = []*Session{}
 }
 
 /*

--- a/gexec/session_test.go
+++ b/gexec/session_test.go
@@ -128,7 +128,10 @@ var _ = Describe("Session", func() {
 	})
 
 	Context("tracking sessions", func() {
-		BeforeEach(ResetTrackedSessions)
+		BeforeEach(func() {
+			KillAndWait()
+		})
+
 		Describe("kill", func() {
 			It("should kill all the started sessions, and not wait", func() {
 				session1, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
@@ -254,28 +257,6 @@ var _ = Describe("Session", func() {
 				Eventually(session1).Should(Exit(128 + 2))
 				Eventually(session2).Should(Exit(128 + 2))
 				Eventually(session3).Should(Exit(128 + 2))
-			})
-		})
-
-		Describe("reset", func() {
-			It("should not track process before the reset", func() {
-				session1, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
-				Ω(err).ShouldNot(HaveOccurred())
-				defer func() { session1.Kill().Wait() }()
-
-				ResetTrackedSessions()
-
-				session2, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
-				Ω(err).ShouldNot(HaveOccurred())
-
-				session3, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
-				Ω(err).ShouldNot(HaveOccurred())
-
-				KillAndWait()
-
-				Ω(session1).ShouldNot(Exit(), "Should not have exited")
-				Ω(session2).Should(Exit(128+9), "Should have exited")
-				Ω(session3).Should(Exit(128+9), "Should have exited")
 			})
 		})
 	})

--- a/gexec/session_test.go
+++ b/gexec/session_test.go
@@ -152,6 +152,25 @@ var _ = Describe("Session", func() {
 				Eventually(session2).Should(Exit(128 + 9))
 				Eventually(session3).Should(Exit(128 + 9))
 			})
+
+			It("should not track unstarted sessions", func() {
+				_, err := Start(exec.Command("does not exist", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).Should(HaveOccurred())
+
+				session2, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				session3, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Kill()
+				Ω(session2).ShouldNot(Exit(), "Should not exit immediately...")
+				Ω(session3).ShouldNot(Exit(), "Should not exit immediately...")
+
+				Eventually(session2).Should(Exit(128 + 9))
+				Eventually(session3).Should(Exit(128 + 9))
+			})
+
 		})
 
 		Describe("killAndWait", func() {

--- a/gexec/session_test.go
+++ b/gexec/session_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Session", func() {
 	})
 
 	Describe("kill", func() {
-		It("should kill the command and wait for it to exit", func() {
+		It("should kill the command and don't wait for it to exit", func() {
 			session, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
 			Ω(err).ShouldNot(HaveOccurred())
 
@@ -124,6 +124,159 @@ var _ = Describe("Session", func() {
 			session.Signal(syscall.SIGABRT)
 			Ω(session).ShouldNot(Exit(), "Should not exit immediately...")
 			Eventually(session).Should(Exit(128 + 6))
+		})
+	})
+
+	Context("tracking sessions", func() {
+		BeforeEach(ResetTrackedSessions)
+		Describe("kill", func() {
+			It("should kill all the started sessions, and not wait", func() {
+				session1, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				session2, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				session3, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Kill()
+				Ω(session1).ShouldNot(Exit(), "Should not exit immediately...")
+				Ω(session2).ShouldNot(Exit(), "Should not exit immediately...")
+				Ω(session3).ShouldNot(Exit(), "Should not exit immediately...")
+
+				Eventually(session1).Should(Exit(128 + 9))
+				Eventually(session2).Should(Exit(128 + 9))
+				Eventually(session3).Should(Exit(128 + 9))
+			})
+		})
+
+		Describe("killAndWait", func() {
+			It("should kill all the started sessions and wait for them to finish", func() {
+				session1, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				session2, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				session3, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				KillAndWait()
+				Ω(session1).Should(Exit(128+9), "Should have exited")
+				Ω(session2).Should(Exit(128+9), "Should have exited")
+				Ω(session3).Should(Exit(128+9), "Should have exited")
+			})
+		})
+
+		Describe("terminate", func() {
+			It("should terminate all the started sessions, and not wait", func() {
+				session1, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				session2, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				session3, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Terminate()
+
+				Ω(session1).ShouldNot(Exit(), "Should not exit immediately...")
+				Ω(session2).ShouldNot(Exit(), "Should not exit immediately...")
+				Ω(session3).ShouldNot(Exit(), "Should not exit immediately...")
+
+				Eventually(session1).Should(Exit(128 + 15))
+				Eventually(session2).Should(Exit(128 + 15))
+				Eventually(session3).Should(Exit(128 + 15))
+			})
+		})
+
+		Describe("terminateAndWait", func() {
+			It("should terminate all the started sessions, and wait for them to exit", func() {
+				session1, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				session2, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				session3, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				TerminateAndWait()
+
+				Ω(session1).Should(Exit(128+15), "Should have exited")
+				Ω(session2).Should(Exit(128+15), "Should have exited")
+				Ω(session3).Should(Exit(128+15), "Should have exited")
+			})
+		})
+
+		Describe("signal", func() {
+			It("should signal all the started sessions, and not wait", func() {
+				session1, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				session2, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				session3, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Signal(syscall.SIGABRT)
+
+				Ω(session1).ShouldNot(Exit(), "Should not exit immediately...")
+				Ω(session2).ShouldNot(Exit(), "Should not exit immediately...")
+				Ω(session3).ShouldNot(Exit(), "Should not exit immediately...")
+
+				Eventually(session1).Should(Exit(128 + 6))
+				Eventually(session2).Should(Exit(128 + 6))
+				Eventually(session3).Should(Exit(128 + 6))
+			})
+		})
+
+		Describe("interrupt", func() {
+			It("should interrupt all the started sessions, and not wait", func() {
+				session1, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				session2, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				session3, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Interrupt()
+
+				Ω(session1).ShouldNot(Exit(), "Should not exit immediately...")
+				Ω(session2).ShouldNot(Exit(), "Should not exit immediately...")
+				Ω(session3).ShouldNot(Exit(), "Should not exit immediately...")
+
+				Eventually(session1).Should(Exit(128 + 2))
+				Eventually(session2).Should(Exit(128 + 2))
+				Eventually(session3).Should(Exit(128 + 2))
+			})
+		})
+
+		Describe("reset", func() {
+			It("should not track process before the reset", func() {
+				session1, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+				defer func() { session1.Kill().Wait() }()
+
+				ResetTrackedSessions()
+
+				session2, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				session3, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				KillAndWait()
+
+				Ω(session1).ShouldNot(Exit(), "Should not have exited")
+				Ω(session2).Should(Exit(128+9), "Should have exited")
+				Ω(session3).Should(Exit(128+9), "Should have exited")
+			})
 		})
 	})
 

--- a/gexec/session_test.go
+++ b/gexec/session_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Session", func() {
 		})
 
 		Describe("kill", func() {
-			It("should kill all the started sessions, and not wait", func() {
+			It("should kill all the started sessions", func() {
 				session1, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
 				Ω(err).ShouldNot(HaveOccurred())
 
@@ -144,13 +144,20 @@ var _ = Describe("Session", func() {
 				Ω(err).ShouldNot(HaveOccurred())
 
 				Kill()
-				Ω(session1).ShouldNot(Exit(), "Should not exit immediately...")
-				Ω(session2).ShouldNot(Exit(), "Should not exit immediately...")
-				Ω(session3).ShouldNot(Exit(), "Should not exit immediately...")
 
 				Eventually(session1).Should(Exit(128 + 9))
 				Eventually(session2).Should(Exit(128 + 9))
 				Eventually(session3).Should(Exit(128 + 9))
+			})
+
+			It("should not wait for exit", func() {
+				session1, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Kill()
+				Ω(session1).ShouldNot(Exit(), "Should not exit immediately...")
+
+				Eventually(session1).Should(Exit(128 + 9))
 			})
 
 			It("should not track unstarted sessions", func() {
@@ -164,8 +171,6 @@ var _ = Describe("Session", func() {
 				Ω(err).ShouldNot(HaveOccurred())
 
 				Kill()
-				Ω(session2).ShouldNot(Exit(), "Should not exit immediately...")
-				Ω(session3).ShouldNot(Exit(), "Should not exit immediately...")
 
 				Eventually(session2).Should(Exit(128 + 9))
 				Eventually(session3).Should(Exit(128 + 9))
@@ -192,7 +197,7 @@ var _ = Describe("Session", func() {
 		})
 
 		Describe("terminate", func() {
-			It("should terminate all the started sessions, and not wait", func() {
+			It("should terminate all the started sessions", func() {
 				session1, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
 				Ω(err).ShouldNot(HaveOccurred())
 
@@ -204,13 +209,18 @@ var _ = Describe("Session", func() {
 
 				Terminate()
 
-				Ω(session1).ShouldNot(Exit(), "Should not exit immediately...")
-				Ω(session2).ShouldNot(Exit(), "Should not exit immediately...")
-				Ω(session3).ShouldNot(Exit(), "Should not exit immediately...")
-
 				Eventually(session1).Should(Exit(128 + 15))
 				Eventually(session2).Should(Exit(128 + 15))
 				Eventually(session3).Should(Exit(128 + 15))
+			})
+
+			It("should not wait for exit", func() {
+				session1, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Terminate()
+
+				Ω(session1).ShouldNot(Exit(), "Should not exit immediately...")
 			})
 		})
 
@@ -234,7 +244,7 @@ var _ = Describe("Session", func() {
 		})
 
 		Describe("signal", func() {
-			It("should signal all the started sessions, and not wait", func() {
+			It("should signal all the started sessions", func() {
 				session1, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
 				Ω(err).ShouldNot(HaveOccurred())
 
@@ -246,13 +256,18 @@ var _ = Describe("Session", func() {
 
 				Signal(syscall.SIGABRT)
 
-				Ω(session1).ShouldNot(Exit(), "Should not exit immediately...")
-				Ω(session2).ShouldNot(Exit(), "Should not exit immediately...")
-				Ω(session3).ShouldNot(Exit(), "Should not exit immediately...")
-
 				Eventually(session1).Should(Exit(128 + 6))
 				Eventually(session2).Should(Exit(128 + 6))
 				Eventually(session3).Should(Exit(128 + 6))
+			})
+
+			It("should not wait", func() {
+				session1, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Signal(syscall.SIGABRT)
+
+				Ω(session1).ShouldNot(Exit(), "Should not exit immediately...")
 			})
 		})
 
@@ -269,13 +284,18 @@ var _ = Describe("Session", func() {
 
 				Interrupt()
 
-				Ω(session1).ShouldNot(Exit(), "Should not exit immediately...")
-				Ω(session2).ShouldNot(Exit(), "Should not exit immediately...")
-				Ω(session3).ShouldNot(Exit(), "Should not exit immediately...")
-
 				Eventually(session1).Should(Exit(128 + 2))
 				Eventually(session2).Should(Exit(128 + 2))
 				Eventually(session3).Should(Exit(128 + 2))
+			})
+
+			It("should not wait", func() {
+				session1, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Interrupt()
+
+				Ω(session1).ShouldNot(Exit(), "Should not exit immediately...")
 			})
 		})
 	})


### PR DESCRIPTION
Providing a mechanism to track and send signals to all the processes started using `Start`. Useful to cleanup processes after the tests, to prevent processes going rogue.

Added the methods:
`Kill`
`KillAndWait`
`Terminate `
`TerminateAndWait`
`Signal `
`Interrupt `
to send signals to all the processes tracked.


resolves #52