### PR TITLE
Print panic object when using ShouldNot(Panic())

### DIFF
--- a/matchers/panic_matcher.go
+++ b/matchers/panic_matcher.go
@@ -42,5 +42,5 @@ func (matcher *PanicMatcher) FailureMessage(actual interface{}) (message string)
 }
 
 func (matcher *PanicMatcher) NegatedFailureMessage(actual interface{}) (message string) {
-	return format.Message(actual, fmt.Sprintf("not to panic, but panicked with <%T>: %v", matcher.object, matcher.object))
+	return format.Message(actual, fmt.Sprintf("not to panic, but panicked with\n%s", format.Object(matcher.object, 1)))
 }

--- a/matchers/panic_matcher.go
+++ b/matchers/panic_matcher.go
@@ -2,11 +2,14 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
 	"reflect"
+
+	"github.com/onsi/gomega/format"
 )
 
-type PanicMatcher struct{}
+type PanicMatcher struct {
+	object interface{}
+}
 
 func (matcher *PanicMatcher) Match(actual interface{}) (success bool, err error) {
 	if actual == nil {
@@ -24,6 +27,7 @@ func (matcher *PanicMatcher) Match(actual interface{}) (success bool, err error)
 	success = false
 	defer func() {
 		if e := recover(); e != nil {
+			matcher.object = e
 			success = true
 		}
 	}()
@@ -38,5 +42,5 @@ func (matcher *PanicMatcher) FailureMessage(actual interface{}) (message string)
 }
 
 func (matcher *PanicMatcher) NegatedFailureMessage(actual interface{}) (message string) {
-	return format.Message(actual, "not to panic")
+	return format.Message(actual, fmt.Sprintf("not to panic, but panicked with <%T>: %v", matcher.object, matcher.object))
 }

--- a/matchers/panic_matcher_test.go
+++ b/matchers/panic_matcher_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Panic", func() {
 			failuresMessages := InterceptGomegaFailures(func() {
 				Ω(func() { panic("ack!") }).ShouldNot(Panic())
 			})
-			Ω(failuresMessages).Should(ConsistOf(ContainSubstring("not to panic, but panicked with <string>: ack!")))
+			Ω(failuresMessages).Should(ConsistOf(MatchRegexp("not to panic, but panicked with\\s*<string>: ack!")))
 		})
 	})
 })

--- a/matchers/panic_matcher_test.go
+++ b/matchers/panic_matcher_test.go
@@ -33,4 +33,13 @@ var _ = Describe("Panic", func() {
 			Ω(func() {}).ShouldNot(Panic())
 		})
 	})
+
+	Context("when assertion fails", func() {
+		It("should print the object passed to Panic", func() {
+			failuresMessages := InterceptGomegaFailures(func() {
+				Ω(func() { panic("ack!") }).ShouldNot(Panic())
+			})
+			Ω(failuresMessages).Should(ConsistOf(ContainSubstring("not to panic, but panicked with <string>: ack!")))
+		})
+	})
 })


### PR DESCRIPTION
When debugging the case where a `Ω(func() { ... }).ShouldNot(Panic())` does actually panic, it's often difficult to understand what happened. This PR prints the objects that was passed to `panic` and makes the debugging process easier.