### PR TITLE
Fix for #175. Printing the map keys incorrectly set the indentation b…

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -6,8 +6,8 @@ package format
 import (
 	"fmt"
 	"reflect"
-	"strings"
 	"strconv"
+	"strings"
 )
 
 // Use MaxDepth to set the maximum recursion depth when printing deeply nested objects
@@ -187,7 +187,7 @@ func formatString(object interface{}, indentation uint) string {
 }
 
 func formatSlice(v reflect.Value, indentation uint) string {
-	if v.Kind() == reflect.Slice && v.Type().Elem().Kind() == reflect.Uint8 && isPrintableString(string(v.Bytes())){
+	if v.Kind() == reflect.Slice && v.Type().Elem().Kind() == reflect.Uint8 && isPrintableString(string(v.Bytes())) {
 		return formatString(v.Bytes(), indentation)
 	}
 
@@ -216,7 +216,7 @@ func formatMap(v reflect.Value, indentation uint) string {
 	longest := 0
 	for i, key := range v.MapKeys() {
 		value := v.MapIndex(key)
-		result[i] = fmt.Sprintf("%s: %s", formatValue(key, 0), formatValue(value, indentation+1))
+		result[i] = fmt.Sprintf("%s: %s", formatValue(key, indentation+1), formatValue(value, indentation+1))
 		if len(result[i]) > longest {
 			longest = len(result[i])
 		}

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -2,11 +2,12 @@ package format_test
 
 import (
 	"fmt"
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
-	"strings"
 )
 
 //recursive struct
@@ -162,19 +163,19 @@ var _ = Describe("Format", func() {
 		})
 
 		Describe("formatting []byte slices", func() {
-      Context("when the slice is made of printable bytes", func () {
-        It("should present it as string", func() {
-          b := []byte("a b c")
-          Ω(Object(b, 1)).Should(matchRegexp(`\[\]uint8 \| len:5, cap:\d+`, `a b c`))
-        })
-      })
-      Context("when the slice contains non-printable bytes", func () {
-        It("should present it as slice", func() {
-          b := []byte("a b c\n\x01\x02\x03\xff\x1bH")
-          Ω(Object(b, 1)).Should(matchRegexp(`\[\]uint8 \| len:12, cap:\d+`,  `\[97, 32, 98, 32, 99, 10, 1, 2, 3, 255, 27, 72\]`))
-        })
-      })
-    })
+			Context("when the slice is made of printable bytes", func() {
+				It("should present it as string", func() {
+					b := []byte("a b c")
+					Ω(Object(b, 1)).Should(matchRegexp(`\[\]uint8 \| len:5, cap:\d+`, `a b c`))
+				})
+			})
+			Context("when the slice contains non-printable bytes", func() {
+				It("should present it as slice", func() {
+					b := []byte("a b c\n\x01\x02\x03\xff\x1bH")
+					Ω(Object(b, 1)).Should(matchRegexp(`\[\]uint8 \| len:12, cap:\d+`, `\[97, 32, 98, 32, 99, 10, 1, 2, 3, 255, 27, 72\]`))
+				})
+			})
+		})
 
 		Describe("formatting functions", func() {
 			It("should give the type and format values correctly", func() {
@@ -428,6 +429,18 @@ var _ = Describe("Format", func() {
 			m["integer"] = 2
 			m["map"] = m
 			Ω(Object(m, 1)).Should(ContainSubstring("..."))
+		})
+
+		It("really should not go crazy...", func() {
+			type complexKey struct {
+				Value map[interface{}]int
+			}
+
+			complexObject := complexKey{}
+			complexObject.Value = make(map[interface{}]int)
+
+			complexObject.Value[&complexObject] = 2
+			Ω(Object(complexObject, 1)).Should(ContainSubstring("..."))
 		})
 	})
 

--- a/matchers/be_numerically_matcher.go
+++ b/matchers/be_numerically_matcher.go
@@ -2,8 +2,9 @@ package matchers
 
 import (
 	"fmt"
-	"github.com/onsi/gomega/format"
 	"math"
+
+	"github.com/onsi/gomega/format"
 )
 
 type BeNumericallyMatcher struct {


### PR DESCRIPTION
…ack to 0

The new context field in http.Request makes the request pretty hard to read. May be worth it to not print the context by default and add a flag to enable context printing. 

See sample request below:

<details><summary>Sample printed request</summary><p>

```
      Received Unhandled Request
      Expected
          <*http.Request | 0xc4202b00f0>: {
              Method: "GET",
              URL: {
                  Scheme: "",
                  Opaque: "",
                  User: nil,
                  Host: "",
                  Path: "/videos/v96623109",
                  RawPath: "",
                  ForceQuery: false,
                  RawQuery: "",
                  Fragment: "",
              },
              Proto: "HTTP/1.1",
              ProtoMajor: 1,
              ProtoMinor: 1,
              Header: {
                  "User-Agent": ["Go-http-client/1.1"],
                  "Accept": [
                      "application/vnd.twitchtv.v3+json",
                  ],
                  "Client-Id": ["some-client-id"],
                  "Accept-Encoding": ["gzip"],
              },
              Body: {
                  eofReaderWithWriteTo: {},
                  Closer: {Reader: nil},
              },
              ContentLength: 0,
              TransferEncoding: nil,
              Close: false,
              Host: "127.0.0.1:64259",
              Form: nil,
              PostForm: nil,
              MultipartForm: nil,
              Trailer: nil,
              RemoteAddr: "127.0.0.1:64267",
              RequestURI: "/videos/v96623109",
              TLS: nil,
              Cancel: nil,
              Response: nil,
              ctx: {
                  Context: {
                      Context: {
                          Context: {
                              Context: 0,
                              key: {name: "http-server"},
                              val: {
                                  Addr: "",
                                  Handler: {
                                      HTTPTestServer: {
                                          URL: "http://127.0.0.1:64259",
                                          Listener: {
                                              fd: {fdmu: ..., sysfd: ..., family: ..., sotype: ..., isConnected: ..., net: ..., laddr: ..., raddr: ..., pd: ...},
                                          },
                                          TLS: nil,
                                          Config: {
                                              Addr: "",
                                              Handler: {
                                                  HTTPTestServer: ...,
                                                  AllowUnhandledRequests: ...,
                                                  UnhandledRequestStatusCode: ...,
                                                  Writer: ...,
                                                  receivedRequests: ...,
                                                  requestHandlers: ...,
                                                  routedHandlers: ...,
                                                  writeLock: ...,
                                                  calls: ...,
                                              },
                                              ReadTimeout: 0,
                                              WriteTimeout: 0,
                                              TLSConfig: {
                                                  Rand: ...,
                                                  Time: ...,
                                                  Certificates: ...,
                                                  NameToCertificate: ...,
                                                  GetCertificate: ...,
                                                  RootCAs: ...,
                                                  NextProtos: ...,
                                                  ServerName: ...,
                                                  ClientAuth: ...,
                                                  ClientCAs: ...,
                                                  InsecureSkipVerify: ...,
                                                  CipherSuites: ...,
                                                  PreferServerCipherSuites: ...,
                                                  SessionTicketsDisabled: ...,
                                                  SessionTicketKey: ...,
                                                  ClientSessionCache: ...,
                                                  MinVersion: ...,
                                                  MaxVersion: ...,
                                                  CurvePreferences: ...,
                                                  DynamicRecordSizingDisabled: ...,
                                                  Renegotiation: ...,
                                                  serverInitOnce: ...,
                                                  mutex: ...,
                                                  sessionTicketKeys: ...,
                                              },
                                              MaxHeaderBytes: 0,
                                              TLSNextProto: {...: ..., ...: ...},
                                              ConnState: 0x267890,
                                              ErrorLog: nil,
                                              disableKeepAlives: 0,
                                              nextProtoOnce: {m: ..., done: ...},
                                              nextProtoErr: nil,
                                          },
                                          wg: {
                                              noCopy: {},
                                              state1: [..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ...],
                                              sema: 0,
                                          },
                                          mu: {state: 0, sema: 0},
                                          closed: false,
                                          conns: {{conn: ...}: 1},
                                      },
                                      AllowUnhandledRequests: false,
                                      UnhandledRequestStatusCode: 500,
                                      Writer: nil,
                                      receivedRequests: [
                                          {
                                              Method: "GET",
                                              URL: {Scheme: ..., Opaque: ..., User: ..., Host: ..., Path: ..., RawPath: ..., ForceQuery: ..., RawQuery: ..., Fragment: ...},
                                              Proto: "HTTP/1.1",
                                              ProtoMajor: 1,
                                              ProtoMinor: 1,
                                              Header: {...: ..., ...: ..., ...: ..., ...: ...},
                                              Body: {
                                                  eofReaderWithWriteTo: ...,
                                                  Closer: ...,
                                              },
                                              ContentLength: 0,
                                              TransferEncoding: nil,
                                              Close: false,
                                              Host: "127.0.0.1:64259",
                                              Form: nil,
                                              PostForm: nil,
                                              MultipartForm: nil,
                                              Trailer: nil,
                                              RemoteAddr: "127.0.0.1:64267",
                                              RequestURI: "/videos/v96623109",
                                              TLS: nil,
                                              Cancel: nil,
                                              Response: nil,
                                              ctx: {Context: ..., done: ..., mu: ..., children: ..., err: ...},
                                          },
                                      ],
                                      requestHandlers: nil,
                                      routedHandlers: [
                                          {
                                              method: "GET",
                                              pathRegexp: nil,
                                              path: "/rechat-messages?start=1477191633&video_id=v9662310",
                                              handler: 0x1833e0,
                                          },
                                          {
                                              method: "GET",
                                              pathRegexp: nil,
                                              path: "/videos/v9662310",
                                              handler: 0x1833e0,
                                          },
                                      ],
                                      writeLock: {state: 0, sema: 0},
                                      calls: 0,
                                  },
                                  ReadTimeout: 0,
                                  WriteTimeout: 0,
                                  TLSConfig: {
                                      Rand: nil,
                                      Time: nil,
                                      Certificates: nil,
                                      NameToCertificate: nil,
                                      GetCertificate: nil,
                                      RootCAs: nil,
                                      NextProtos: ["h2", "h2-14"],
                                      ServerName: "",
                                      ClientAuth: 0,
                                      ClientCAs: nil,
                                      InsecureSkipVerify: false,
                                      CipherSuites: nil,
                                      PreferServerCipherSuites: true,
                                      SessionTicketsDisabled: false,
                                      SessionTicketKey: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                                      ClientSessionCache: nil,
                                      MinVersion: 0,
                                      MaxVersion: 0,
                                      CurvePreferences: nil,
                                      DynamicRecordSizingDisabled: false,
                                      Renegotiation: 0,
                                      serverInitOnce: {
                                          m: {state: 0, sema: 0},
                                          done: 0,
                                      },
                                      mutex: {
                                          w: {state: 0, sema: 0},
                                          writerSem: 0,
                                          readerSem: 0,
                                          readerCount: 0,
                                          readerWait: 0,
                                      },
                                      sessionTicketKeys: nil,
                                  },
                                  MaxHeaderBytes: 0,
                                  TLSNextProto: {"h2": 0x14a9b0, "h2-14": 0x14a9b0},
                                  ConnState: 0x267890,
                                  ErrorLog: nil,
                                  disableKeepAlives: 0,
                                  nextProtoOnce: {
                                      m: {state: 0, sema: 0},
                                      done: 1,
                                  },
                                  nextProtoErr: nil,
                              },
                          },
                          key: {name: "local-addr"},
                          val: {IP: [127, 0, 0, 1], Port: 64259, Zone: ""},
                      },
                      done: 0xc4202a05a0,
                      mu: {state: 0, sema: 0},
                      children: {
                          {
                              Context: {
                                  Context: {
                                      Context: {
                                          Context: 0,
                                          key: {name: "http-server"},
                                          val: {
                                              Addr: "",
                                              Handler: {
                                                  HTTPTestServer: ...,
                                                  AllowUnhandledRequests: ...,
                                                  UnhandledRequestStatusCode: ...,
                                                  Writer: ...,
                                                  receivedRequests: ...,
                                                  requestHandlers: ...,
                                                  routedHandlers: ...,
                                                  writeLock: ...,
                                                  calls: ...,
                                              },
                                              ReadTimeout: 0,
                                              WriteTimeout: 0,
                                              TLSConfig: {
                                                  Rand: ...,
                                                  Time: ...,
                                                  Certificates: ...,
                                                  NameToCertificate: ...,
                                                  GetCertificate: ...,
                                                  RootCAs: ...,
                                                  NextProtos: ...,
                                                  ServerName: ...,
                                                  ClientAuth: ...,
                                                  ClientCAs: ...,
                                                  InsecureSkipVerify: ...,
                                                  CipherSuites: ...,
                                                  PreferServerCipherSuites: ...,
                                                  SessionTicketsDisabled: ...,
                                                  SessionTicketKey: ...,
                                                  ClientSessionCache: ...,
                                                  MinVersion: ...,
                                                  MaxVersion: ...,
                                                  CurvePreferences: ...,
                                                  DynamicRecordSizingDisabled: ...,
                                                  Renegotiation: ...,
                                                  serverInitOnce: ...,
                                                  mutex: ...,
                                                  sessionTicketKeys: ...,
                                              },
                                              MaxHeaderBytes: 0,
                                              TLSNextProto: {...: ..., ...: ...},
                                              ConnState: 0x267890,
                                              ErrorLog: nil,
                                              disableKeepAlives: 0,
                                              nextProtoOnce: {m: ..., done: ...},
                                              nextProtoErr: nil,
                                          },
                                      },
                                      key: {name: "local-addr"},
                                      val: {IP: [127, 0, 0, 1], Port: 64259, Zone: ""},
                                  },
                                  done: 0xc4202a05a0,
                                  mu: {state: 0, sema: 0},
                                  children: {
                                      {
                                          Context: {
                                              Context: {Context: ..., key: ..., val: ...},
                                              done: 0xc4202a05a0,
                                              mu: {state: ..., sema: ...},
                                              children: {...: ...},
                                              err: nil,
                                          },
                                          done: 0xc4202a0600,
                                          mu: {state: 0, sema: 0},
                                          children: nil,
                                          err: nil,
                                      }: true,
                                  },
                                  err: nil,
                              },
                              done: 0xc4202a0600,
                              mu: {state: 0, sema: 0},
                              children: nil,
                              err: nil,
                          }: true,
                      },
                      err: nil,
                  },
                  done: 0xc4202a0600,
                  mu: {state: 0, sema: 0},
                  children: nil,
                  err: nil,
              },
          }
      to be nil
```

</p></details>
