### PR TITLE
Add gexec.BuildWithEnvironment

### DIFF
--- a/gexec/build.go
+++ b/gexec/build.go
@@ -30,7 +30,7 @@ func Build(packagePath string, args ...string) (compiledPath string, err error) 
 /*
 BuildWithEnvironment is identical to Build but allows you to specify env vars to be set at build time.
 */
-func BuildWithEnvironment(packagePath string, env map[string]string, args ...string) (compiledPath string, err error) {
+func BuildWithEnvironment(packagePath string, env []string, args ...string) (compiledPath string, err error) {
 	return doBuild(os.Getenv("GOPATH"), packagePath, env, args...)
 }
 
@@ -41,7 +41,7 @@ func BuildIn(gopath string, packagePath string, args ...string) (compiledPath st
 	return doBuild(gopath, packagePath, nil, args...)
 }
 
-func doBuild(gopath, packagePath string, env map[string]string, args ...string) (compiledPath string, err error) {
+func doBuild(gopath, packagePath string, env []string, args ...string) (compiledPath string, err error) {
 	tmpDir, err := temporaryDirectory()
 	if err != nil {
 		return "", err
@@ -61,11 +61,7 @@ func doBuild(gopath, packagePath string, env map[string]string, args ...string) 
 
 	build := exec.Command("go", cmdArgs...)
 	build.Env = append([]string{"GOPATH=" + gopath}, os.Environ()...)
-
-	for k, v := range env {
-		envVar := k + "=" + v
-		build.Env = append(build.Env, envVar)
-	}
+	build.Env = append(build.Env, env...)
 
 	output, err := build.CombinedOutput()
 	if err != nil {

--- a/gexec/build.go
+++ b/gexec/build.go
@@ -28,6 +28,18 @@ func Build(packagePath string, args ...string) (compiledPath string, err error) 
 }
 
 /*
+BuildWithEnvironment is identical to Build but allows you to specify env vars to be set at build time.
+*/
+func BuildWithEnvironment(packagePath string, env map[string]string, args ...string) (compiledPath string, err error) {
+	for key, val := range env {
+		os.Setenv(key, val)
+		defer os.Unsetenv(key)
+	}
+
+	return BuildIn(os.Getenv("GOPATH"), packagePath, args...)
+}
+
+/*
 BuildIn is identical to Build but allows you to specify a custom $GOPATH (the first argument).
 */
 func BuildIn(gopath string, packagePath string, args ...string) (compiledPath string, err error) {

--- a/gexec/build.go
+++ b/gexec/build.go
@@ -24,25 +24,24 @@ A path pointing to this binary is returned.
 Build uses the $GOPATH set in your environment.  It passes the variadic args on to `go build`.
 */
 func Build(packagePath string, args ...string) (compiledPath string, err error) {
-	return BuildIn(os.Getenv("GOPATH"), packagePath, args...)
+	return doBuild(os.Getenv("GOPATH"), packagePath, nil, args...)
 }
 
 /*
 BuildWithEnvironment is identical to Build but allows you to specify env vars to be set at build time.
 */
 func BuildWithEnvironment(packagePath string, env map[string]string, args ...string) (compiledPath string, err error) {
-	for key, val := range env {
-		os.Setenv(key, val)
-		defer os.Unsetenv(key)
-	}
-
-	return BuildIn(os.Getenv("GOPATH"), packagePath, args...)
+	return doBuild(os.Getenv("GOPATH"), packagePath, env, args...)
 }
 
 /*
 BuildIn is identical to Build but allows you to specify a custom $GOPATH (the first argument).
 */
 func BuildIn(gopath string, packagePath string, args ...string) (compiledPath string, err error) {
+	return doBuild(gopath, packagePath, nil, args...)
+}
+
+func doBuild(gopath, packagePath string, env map[string]string, args ...string) (compiledPath string, err error) {
 	tmpDir, err := temporaryDirectory()
 	if err != nil {
 		return "", err
@@ -62,6 +61,11 @@ func BuildIn(gopath string, packagePath string, args ...string) (compiledPath st
 
 	build := exec.Command("go", cmdArgs...)
 	build.Env = append([]string{"GOPATH=" + gopath}, os.Environ()...)
+
+	for k, v := range env {
+		envVar := k + "=" + v
+		build.Env = append(build.Env, envVar)
+	}
 
 	output, err := build.CombinedOutput()
 	if err != nil {

--- a/gexec/build_test.go
+++ b/gexec/build_test.go
@@ -40,9 +40,9 @@ var _ = Describe(".Build", func() {
 
 var _ = Describe(".BuildWithEnvironment", func() {
 	var err error
-	env := map[string]string{
-		"GOOS":   "linux",
-		"GOARCH": "amd64",
+	env := []string{
+		"GOOS=linux",
+		"GOARCH=amd64",
 	}
 
 	It("compiles the specified package with the specified env vars", func() {

--- a/gexec/build_test.go
+++ b/gexec/build_test.go
@@ -40,28 +40,20 @@ var _ = Describe(".Build", func() {
 
 var _ = Describe(".BuildWithEnvironment", func() {
 	var err error
+	env := map[string]string{
+		"GOOS":   "linux",
+		"GOARCH": "amd64",
+	}
 
 	It("compiles the specified package with the specified env vars", func() {
-		env := map[string]string{
-			"GOOS":   "linux",
-			"GOARCH": "amd64",
-		}
-
 		compiledPath, err := gexec.BuildWithEnvironment(packagePath, env)
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(compiledPath).Should(BeAnExistingFile())
 	})
 
 	It("returns the environment to a good state", func() {
-		knownGoodEnv := os.Environ()
-
-		env := map[string]string{
-			"THIS_ENV_VAR": "SHOULD_NOT_BE_SET",
-		}
-
 		_, err = gexec.BuildWithEnvironment(packagePath, env)
 		Ω(err).ShouldNot(HaveOccurred())
-
-		Ω(os.Environ()).Should(Equal(knownGoodEnv))
+		Ω(os.Environ()).ShouldNot(ContainElement("GOOS=linux"))
 	})
 })

--- a/gexec/build_test.go
+++ b/gexec/build_test.go
@@ -1,14 +1,16 @@
 package gexec_test
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 )
 
-var _ = Describe(".Build", func() {
-	var packagePath = "./_fixture/firefly"
+var packagePath = "./_fixture/firefly"
 
+var _ = Describe(".Build", func() {
 	Context("when there have been previous calls to Build", func() {
 		BeforeEach(func() {
 			_, err := gexec.Build(packagePath)
@@ -33,5 +35,33 @@ var _ = Describe(".Build", func() {
 				Ω(fireflyPath).Should(BeAnExistingFile())
 			})
 		})
+	})
+})
+
+var _ = Describe(".BuildWithEnvironment", func() {
+	var err error
+
+	It("compiles the specified package with the specified env vars", func() {
+		env := map[string]string{
+			"GOOS":   "linux",
+			"GOARCH": "amd64",
+		}
+
+		compiledPath, err := gexec.BuildWithEnvironment(packagePath, env)
+		Ω(err).ShouldNot(HaveOccurred())
+		Ω(compiledPath).Should(BeAnExistingFile())
+	})
+
+	It("returns the environment to a good state", func() {
+		knownGoodEnv := os.Environ()
+
+		env := map[string]string{
+			"THIS_ENV_VAR": "SHOULD_NOT_BE_SET",
+		}
+
+		_, err = gexec.BuildWithEnvironment(packagePath, env)
+		Ω(err).ShouldNot(HaveOccurred())
+
+		Ω(os.Environ()).Should(Equal(knownGoodEnv))
 	})
 })


### PR DESCRIPTION
Accepts a map of env vars as key-value pairs which are set during compilation. Useful for building a binary that gets tested on a remote VM/in a container that uses a different architecture to your local machine.

Resolves #177.