### PR TITLE
Attempt to diff long strings when not equal

### DIFF
--- a/format/format_test.go
+++ b/format/format_test.go
@@ -130,6 +130,29 @@ var _ = Describe("Format", func() {
 		})
 	})
 
+	Describe("MessageWithDiff", func() {
+		It("shows the exact point where two long strings differ", func() {
+			stringWithB := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			stringWithZ := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaazaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+			Ω(MessageWithDiff(stringWithB, "to equal", stringWithZ)).Should(Equal(expectedLongStringFailureMessage))
+		})
+
+		It("truncates the start of long strings that differ only at their end", func() {
+			stringWithB := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"
+			stringWithZ := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz"
+
+			Ω(MessageWithDiff(stringWithB, "to equal", stringWithZ)).Should(Equal(expectedTruncatedStartStringFailureMessage))
+		})
+
+		It("truncates the end of long strings that differ only at their start", func() {
+			stringWithB := "baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			stringWithZ := "zaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+			Ω(MessageWithDiff(stringWithB, "to equal", stringWithZ)).Should(Equal(expectedTruncatedEndStringFailureMessage))
+		})
+	})
+
 	Describe("IndentString", func() {
 		It("should indent the string", func() {
 			Ω(IndentString("foo\n  bar\nbaz", 2)).Should(Equal("        foo\n          bar\n        baz"))
@@ -526,3 +549,28 @@ var _ = Describe("Format", func() {
 		})
 	})
 })
+
+var expectedShortStringFailureMessage = strings.TrimSpace(`
+Expected
+    <string>: tim
+to equal
+    <string>: eric
+`)
+var expectedLongStringFailureMessage = strings.TrimSpace(`
+Expected
+    <string>: "...aaaaabaaaaa..."
+to equal               |
+    <string>: "...aaaaazaaaaa..."
+`)
+var expectedTruncatedEndStringFailureMessage = strings.TrimSpace(`
+Expected
+    <string>: "baaaaa..."
+to equal       |
+    <string>: "zaaaaa..."
+`)
+var expectedTruncatedStartStringFailureMessage = strings.TrimSpace(`
+Expected
+    <string>: "...aaaaab"
+to equal               |
+    <string>: "...aaaaaz"
+`)

--- a/matchers/equal_matcher.go
+++ b/matchers/equal_matcher.go
@@ -19,6 +19,12 @@ func (matcher *EqualMatcher) Match(actual interface{}) (success bool, err error)
 }
 
 func (matcher *EqualMatcher) FailureMessage(actual interface{}) (message string) {
+	actualString, actualOK := actual.(string)
+	expectedString, expectedOK := matcher.Expected.(string)
+	if actualOK && expectedOK {
+		return format.MessageWithDiff(actualString, "to equal", expectedString)
+	}
+
 	return format.Message(actual, "to equal", matcher.Expected)
 }
 

--- a/matchers/equal_matcher_test.go
+++ b/matchers/equal_matcher_test.go
@@ -2,6 +2,8 @@ package matchers_test
 
 import (
 	"errors"
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/matchers"
@@ -41,4 +43,36 @@ var _ = Describe("Equal", func() {
 			Ω(myCustomType{s: "foo", n: 3, f: 2.0, arr: []string{"a", "b"}}).ShouldNot(Equal(myCustomType{s: "foo", n: 3, f: 2.0, arr: []string{"a", "b", "c"}}))
 		})
 	})
+
+	Describe("failure messages", func() {
+		It("shows the two strings simply when they are short", func() {
+			subject := EqualMatcher{Expected: "eric"}
+
+			failureMessage := subject.FailureMessage("tim")
+			Ω(failureMessage).To(BeEquivalentTo(expectedShortStringFailureMessage))
+		})
+
+		It("shows the exact point where two long strings differ", func() {
+			stringWithB := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			stringWithZ := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaazaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+			subject := EqualMatcher{Expected: stringWithZ}
+
+			failureMessage := subject.FailureMessage(stringWithB)
+			Ω(failureMessage).To(BeEquivalentTo(expectedLongStringFailureMessage))
+		})
+	})
 })
+
+var expectedShortStringFailureMessage = strings.TrimSpace(`
+Expected
+    <string>: tim
+to equal
+    <string>: eric
+`)
+var expectedLongStringFailureMessage = strings.TrimSpace(`
+Expected
+    <string>: "...aaaaabaaaaa..."
+to equal               |
+    <string>: "...aaaaazaaaaa..."
+`)


### PR DESCRIPTION
Our goal in this PR was to improve the UX for `Equal()` when both of the expected and actual are very, very long strings.

Long strings (with more than 50 characters) that are not equal are typically
hard to visually diff when your tests fail. This change attempts to find the
very first mismatch in the strings and to visually point out where the diff
is. It additionally truncates the text, so it is easier to see the exact point.

Assumptions:
* people only need ~5 characters around the diff to identify WHERE it is
* 50 characters is a reasonable threshold for deciding to diff strings in this manner
* Equal() is the only matcher that needs this treatment (for now)

Would love feedback on these assumptions, or anything else.