### PR TITLE
format can diff strings that differ only in length

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -124,9 +124,16 @@ func findFirstMismatch(a, b string) int {
 	bSlice := strings.Split(b, "")
 
 	for index, str := range aSlice {
+		if index > len(b) - 1 {
+			return index
+		}
 		if str != bSlice[index] {
 			return index
 		}
+	}
+
+	if len(b) > len(a) {
+		return len(a) + 1
 	}
 
 	return 0

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -145,6 +145,14 @@ var _ = Describe("Format", func() {
 			Ω(MessageWithDiff(stringWithB, "to equal", stringWithZ)).Should(Equal(expectedTruncatedStartStringFailureMessage))
 		})
 
+		It("truncates the start of long strings that differ only in length", func() {
+			smallString := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			largeString := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+			Ω(MessageWithDiff(largeString, "to equal", smallString)).Should(Equal(expectedTruncatedStartSizeFailureMessage))
+			Ω(MessageWithDiff(smallString, "to equal", largeString)).Should(Equal(expectedTruncatedStartSizeSwappedFailureMessage))
+		})
+
 		It("truncates the end of long strings that differ only at their start", func() {
 			stringWithB := "baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 			stringWithZ := "zaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -567,4 +575,16 @@ Expected
     <string>: "...aaaaab"
 to equal               |
     <string>: "...aaaaaz"
+`)
+var expectedTruncatedStartSizeFailureMessage = strings.TrimSpace(`
+Expected
+    <string>: "...aaaaaa"
+to equal               |
+    <string>: "...aaaaa"
+`)
+var expectedTruncatedStartSizeSwappedFailureMessage = strings.TrimSpace(`
+Expected
+    <string>: "...aaaa"
+to equal              |
+    <string>: "...aaaaa"
 `)

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -550,12 +550,6 @@ var _ = Describe("Format", func() {
 	})
 })
 
-var expectedShortStringFailureMessage = strings.TrimSpace(`
-Expected
-    <string>: tim
-to equal
-    <string>: eric
-`)
 var expectedLongStringFailureMessage = strings.TrimSpace(`
 Expected
     <string>: "...aaaaabaaaaa..."


### PR DESCRIPTION
Previous behavior panicked when trying to compare beyond the string bounds.