### PR TITLE
Report first instance of mismatch for JSON matcher

### DIFF
--- a/matchers/match_json_matcher.go
+++ b/matchers/match_json_matcher.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/onsi/gomega/format"
 )
 
 type MatchJSONMatcher struct {
-	JSONToMatch interface{}
+	JSONToMatch      interface{}
+	firstFailurePath []interface{}
 }
 
 func (matcher *MatchJSONMatcher) Match(actual interface{}) (success bool, err error) {
@@ -25,18 +27,45 @@ func (matcher *MatchJSONMatcher) Match(actual interface{}) (success bool, err er
 	// this is guarded by prettyPrint
 	json.Unmarshal([]byte(actualString), &aval)
 	json.Unmarshal([]byte(expectedString), &eval)
-
-	return reflect.DeepEqual(aval, eval), nil
+	var equal bool
+	equal, matcher.firstFailurePath = deepEqual(aval, eval)
+	return equal, nil
 }
 
 func (matcher *MatchJSONMatcher) FailureMessage(actual interface{}) (message string) {
 	actualString, expectedString, _ := matcher.prettyPrint(actual)
-	return format.Message(actualString, "to match JSON of", expectedString)
+	return formattedMessage(format.Message(actualString, "to match JSON of", expectedString), matcher.firstFailurePath)
 }
 
 func (matcher *MatchJSONMatcher) NegatedFailureMessage(actual interface{}) (message string) {
 	actualString, expectedString, _ := matcher.prettyPrint(actual)
-	return format.Message(actualString, "not to match JSON of", expectedString)
+	return formattedMessage(format.Message(actualString, "not to match JSON of", expectedString), matcher.firstFailurePath)
+}
+
+func formattedMessage(comparisonMessage string, failurePath []interface{}) string {
+	var diffMessage string
+	if len(failurePath) == 0 {
+		diffMessage = ""
+	} else {
+		diffMessage = fmt.Sprintf("\n\nfirst mismatched key: %s", formattedFailurePath(failurePath))
+	}
+	return fmt.Sprintf("%s%s", comparisonMessage, diffMessage)
+}
+
+func formattedFailurePath(failurePath []interface{}) string {
+	formattedPaths := []string{}
+	for i := len(failurePath) - 1; i >= 0; i-- {
+		switch p := failurePath[i].(type) {
+		case int:
+			formattedPaths = append(formattedPaths, fmt.Sprintf(`[%d]`, p))
+		default:
+			if i != len(failurePath)-1 {
+				formattedPaths = append(formattedPaths, ".")
+			}
+			formattedPaths = append(formattedPaths, fmt.Sprintf(`"%s"`, p))
+		}
+	}
+	return strings.Join(formattedPaths, "")
 }
 
 func (matcher *MatchJSONMatcher) prettyPrint(actual interface{}) (actualFormatted, expectedFormatted string, err error) {
@@ -61,4 +90,42 @@ func (matcher *MatchJSONMatcher) prettyPrint(actual interface{}) (actualFormatte
 	}
 
 	return abuf.String(), ebuf.String(), nil
+}
+
+func deepEqual(a interface{}, b interface{}) (bool, []interface{}) {
+	var errorPath []interface{}
+	if reflect.TypeOf(a) != reflect.TypeOf(b) {
+		return false, errorPath
+	}
+
+	switch a.(type) {
+	case []interface{}:
+		if len(a.([]interface{})) != len(b.([]interface{})) {
+			return false, errorPath
+		}
+
+		for i, v := range a.([]interface{}) {
+			elementEqual, keyPath := deepEqual(v, b.([]interface{})[i])
+			if !elementEqual {
+				return false, append(keyPath, i)
+			}
+		}
+		return true, errorPath
+
+	case map[string]interface{}:
+		if len(a.(map[string]interface{})) != len(b.(map[string]interface{})) {
+			return false, errorPath
+		}
+
+		for k, v := range a.(map[string]interface{}) {
+			elementEqual, keyPath := deepEqual(v, b.(map[string]interface{})[k])
+			if !elementEqual {
+				return false, append(keyPath, k)
+			}
+		}
+		return true, errorPath
+
+	default:
+		return a == b, errorPath
+	}
 }

--- a/matchers/match_json_matcher_test.go
+++ b/matchers/match_json_matcher_test.go
@@ -25,6 +25,24 @@ var _ = Describe("MatchJSONMatcher", func() {
 		})
 	})
 
+	Context("when a key mismatch is found", func() {
+		It("reports the first found mismatch", func() {
+			subject := MatchJSONMatcher{JSONToMatch: `5`}
+			actual := `7`
+			subject.Match(actual)
+
+			failureMessage := subject.FailureMessage(`7`)
+			Ω(failureMessage).ToNot(ContainSubstring("first mismatched key"))
+
+			subject = MatchJSONMatcher{JSONToMatch: `{"a": 1, "b.g": {"c": 2, "1": ["hello", "see ya"]}}`}
+			actual = `{"a": 1, "b.g": {"c": 2, "1": ["hello", "goodbye"]}}`
+			subject.Match(actual)
+
+			failureMessage = subject.FailureMessage(actual)
+			Ω(failureMessage).To(ContainSubstring(`first mismatched key: "b.g"."1"[1]`))
+		})
+	})
+
 	Context("when the expected is not valid JSON", func() {
 		It("should error and explain why", func() {
 			success, err := (&MatchJSONMatcher{JSONToMatch: `{}`}).Match(`oops`)


### PR DESCRIPTION
For example, when comparing these two JSON structures:

```
{"a": 1, "b.g": {"c": 2, "1": ["hello", "see ya"]}}
{"a": 1, "b.g": {"c": 2, "1": ["hello", "goodbye"]}}
```

The failure message will now include an extra line saying:

```
first mismatched key: "b.g"."1"[1]
```

Signed-off-by: Dan Wendorf <dwendorf@pivotal.io>