### PR TITLE
Adds support for MatchXML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
   - 1.6
   - 1.7
+  - 1.8
 
 install:
   - go get -v ./...

--- a/matchers.go
+++ b/matchers.go
@@ -214,6 +214,20 @@ func MatchJSON(json interface{}) types.GomegaMatcher {
 	}
 }
 
+//MatchXML succeeds if actual is a string or stringer of XML that matches
+//the expected XML.  The XMLs are decoded and the resulting objects are compared via
+//reflect.DeepEqual so things like key-ordering and whitespace shouldn't matter.
+//The comparison of attribute values is not supported for go1.7 and before.
+//For go1.7, the two following XMLs are equal:
+//<person gender="female">
+//
+//<person gender="male">
+func MatchXML(xml interface{}) types.GomegaMatcher {
+	return &matchers.MatchXMLMatcher{
+		XMLToMatch: xml,
+	}
+}
+
 //MatchYAML succeeds if actual is a string or stringer of YAML that matches
 //the expected YAML.  The YAML's are decoded and the resulting objects are compared via
 //reflect.DeepEqual so things like key-ordering and whitespace shouldn't matter.

--- a/matchers/match_xml_matcher.go
+++ b/matchers/match_xml_matcher.go
@@ -1,0 +1,58 @@
+package matchers
+
+import (
+	"encoding/xml"
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/gomega/format"
+)
+
+type MatchXMLMatcher struct {
+	XMLToMatch interface{}
+}
+
+func (matcher *MatchXMLMatcher) Match(actual interface{}) (success bool, err error) {
+	actualString, expectedString, err := matcher.formattedPrint(actual)
+	if err != nil {
+		return false, err
+	}
+
+	aval := &xmlNode{}
+	eval := &xmlNode{}
+
+	if err := xml.Unmarshal([]byte(actualString), aval); err != nil {
+		return false, fmt.Errorf("Actual '%s' should be valid XML, but it is not.\nUnderlying error:%s", actualString, err)
+	}
+	if err := xml.Unmarshal([]byte(expectedString), eval); err != nil {
+		return false, fmt.Errorf("Expected '%s' should be valid XML, but it is not.\nUnderlying error:%s", expectedString, err)
+	}
+
+	aval.Clean()
+	eval.Clean()
+
+	return reflect.DeepEqual(aval, eval), nil
+}
+
+func (matcher *MatchXMLMatcher) FailureMessage(actual interface{}) (message string) {
+	actualString, expectedString, _ := matcher.formattedPrint(actual)
+	return fmt.Sprintf("Expected\n%s\nto match XML of\n%s", actualString, expectedString)
+}
+
+func (matcher *MatchXMLMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	actualString, expectedString, _ := matcher.formattedPrint(actual)
+	return fmt.Sprintf("Expected\n%s\nnot to match XML of\n%s", actualString, expectedString)
+}
+
+func (matcher *MatchXMLMatcher) formattedPrint(actual interface{}) (actualString, expectedString string, err error) {
+	var ok bool
+	actualString, ok = toString(actual)
+	if !ok {
+		return "", "", fmt.Errorf("MatchXMLMatcher matcher requires a string, stringer, or []byte.  Got actual:\n%s", format.Object(actual, 1))
+	}
+	expectedString, ok = toString(matcher.XMLToMatch)
+	if !ok {
+		return "", "", fmt.Errorf("MatchXMLMatcher matcher requires a string, stringer, or []byte.  Got expected:\n%s", format.Object(matcher.XMLToMatch, 1))
+	}
+	return actualString, expectedString, nil
+}

--- a/matchers/match_xml_matcher_go1.8_test.go
+++ b/matchers/match_xml_matcher_go1.8_test.go
@@ -1,0 +1,22 @@
+// +build go1.8
+
+package matchers_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MatchXMLMatcher Go 1.8", func() {
+
+	var (
+		sample_09 = readFileContents("test_data/xml/sample_09.xml")
+		sample_10 = readFileContents("test_data/xml/sample_10.xml")
+	)
+
+	Context("When passed stringifiables", func() {
+		It("should succeed if the XML matches", func() {
+			Ω(sample_09).ShouldNot(MatchXML(sample_10)) // same structures with different attribute values
+		})
+	})
+})

--- a/matchers/match_xml_matcher_test.go
+++ b/matchers/match_xml_matcher_test.go
@@ -1,0 +1,85 @@
+package matchers_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/matchers"
+)
+
+var _ = Describe("MatchXMLMatcher", func() {
+
+	var (
+		sample_01 = readFileContents("test_data/xml/sample_01.xml")
+		sample_02 = readFileContents("test_data/xml/sample_02.xml")
+		sample_03 = readFileContents("test_data/xml/sample_03.xml")
+		sample_04 = readFileContents("test_data/xml/sample_04.xml")
+		sample_05 = readFileContents("test_data/xml/sample_05.xml")
+		sample_06 = readFileContents("test_data/xml/sample_06.xml")
+		sample_07 = readFileContents("test_data/xml/sample_07.xml")
+		sample_08 = readFileContents("test_data/xml/sample_08.xml")
+	)
+
+	Context("When passed stringifiables", func() {
+		It("should succeed if the XML matches", func() {
+			Ω(sample_01).Should(MatchXML(sample_01))    // same XML
+			Ω(sample_01).Should(MatchXML(sample_02))    // same XML with blank lines
+			Ω(sample_01).Should(MatchXML(sample_03))    // same XML with different formatting
+			Ω(sample_01).ShouldNot(MatchXML(sample_04)) // same structures with different values
+			Ω(sample_01).ShouldNot(MatchXML(sample_05)) // different structures
+			Ω(sample_06).ShouldNot(MatchXML(sample_07)) // same xml names with different namespaces
+			Ω(sample_07).ShouldNot(MatchXML(sample_08)) // same structures with different values
+		})
+
+		It("should work with byte arrays", func() {
+			Ω([]byte(sample_01)).Should(MatchXML([]byte(sample_01)))
+			Ω([]byte(sample_01)).Should(MatchXML(sample_01))
+			Ω(sample_01).Should(MatchXML([]byte(sample_01)))
+		})
+	})
+
+	Context("when the expected is not valid XML", func() {
+		It("should error and explain why", func() {
+			success, err := (&MatchXMLMatcher{XMLToMatch: sample_01}).Match(`oops`)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring("Actual 'oops' should be valid XML"))
+		})
+	})
+
+	Context("when the actual is not valid XML", func() {
+		It("should error and explain why", func() {
+			success, err := (&MatchXMLMatcher{XMLToMatch: `oops`}).Match(sample_01)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring("Expected 'oops' should be valid XML"))
+		})
+	})
+
+	Context("when the expected is neither a string nor a stringer nor a byte array", func() {
+		It("should error", func() {
+			success, err := (&MatchXMLMatcher{XMLToMatch: 2}).Match(sample_01)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring("MatchXMLMatcher matcher requires a string, stringer, or []byte.  Got expected:\n    <int>: 2"))
+
+			success, err = (&MatchXMLMatcher{XMLToMatch: nil}).Match(sample_01)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring("MatchXMLMatcher matcher requires a string, stringer, or []byte.  Got expected:\n    <nil>: nil"))
+		})
+	})
+
+	Context("when the actual is neither a string nor a stringer nor a byte array", func() {
+		It("should error", func() {
+			success, err := (&MatchXMLMatcher{XMLToMatch: sample_01}).Match(2)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring("MatchXMLMatcher matcher requires a string, stringer, or []byte.  Got actual:\n    <int>: 2"))
+
+			success, err = (&MatchXMLMatcher{XMLToMatch: sample_01}).Match(nil)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring("MatchXMLMatcher matcher requires a string, stringer, or []byte.  Got actual:\n    <nil>: nil"))
+		})
+	})
+})

--- a/matchers/matcher_tests_suite_test.go
+++ b/matchers/matcher_tests_suite_test.go
@@ -1,6 +1,9 @@
 package matchers_test
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -27,4 +30,21 @@ type myCustomType struct {
 func Test(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Gomega Matchers")
+}
+
+func readFileContents(filePath string) []byte {
+	f := openFile(filePath)
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		panic(fmt.Errorf("failed to read file contents: %v", err))
+	}
+	return b
+}
+
+func openFile(filePath string) *os.File {
+	f, err := os.Open(filePath)
+	if err != nil {
+		panic(fmt.Errorf("failed to open file: %v", err))
+	}
+	return f
 }

--- a/matchers/test_data/xml/sample_01.xml
+++ b/matchers/test_data/xml/sample_01.xml
@@ -1,0 +1,6 @@
+<note>
+    <to>Tove</to>
+    <from>Jani</from>
+    <heading>Reminder</heading>
+    <body>Don't forget me this weekend!</body>
+</note>

--- a/matchers/test_data/xml/sample_02.xml
+++ b/matchers/test_data/xml/sample_02.xml
@@ -1,0 +1,9 @@
+
+
+<note>
+    <to>Tove</to>
+    <from>Jani</from>
+    <heading>Reminder</heading>
+    <body>Don't forget me this weekend!</body>
+</note>
+

--- a/matchers/test_data/xml/sample_03.xml
+++ b/matchers/test_data/xml/sample_03.xml
@@ -1,0 +1,1 @@
+<note> <to>Tove</to> <from>Jani</from> <heading>Reminder</heading> <body>Don't forget me this weekend!</body> </note>

--- a/matchers/test_data/xml/sample_04.xml
+++ b/matchers/test_data/xml/sample_04.xml
@@ -1,0 +1,6 @@
+<note>
+    <to>Tove</to>
+    <from>John</from>
+    <heading>Doe</heading>
+    <body>Don't forget me this weekend!</body>
+</note>

--- a/matchers/test_data/xml/sample_05.xml
+++ b/matchers/test_data/xml/sample_05.xml
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CATALOG>
+  <CD>
+    <TITLE>Empire Burlesque</TITLE>
+    <ARTIST>Bob Dylan</ARTIST>
+    <COUNTRY>USA</COUNTRY>
+    <COMPANY>Columbia</COMPANY>
+    <PRICE>10.90</PRICE>
+    <YEAR>1985</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Hide your heart</TITLE>
+    <ARTIST>Bonnie Tyler</ARTIST>
+    <COUNTRY>UK</COUNTRY>
+    <COMPANY>CBS Records</COMPANY>
+    <PRICE>9.90</PRICE>
+    <YEAR>1988</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Greatest Hits</TITLE>
+    <ARTIST>Dolly Parton</ARTIST>
+    <COUNTRY>USA</COUNTRY>
+    <COMPANY>RCA</COMPANY>
+    <PRICE>9.90</PRICE>
+    <YEAR>1982</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Still got the blues</TITLE>
+    <ARTIST>Gary Moore</ARTIST>
+    <COUNTRY>UK</COUNTRY>
+    <COMPANY>Virgin records</COMPANY>
+    <PRICE>10.20</PRICE>
+    <YEAR>1990</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Eros</TITLE>
+    <ARTIST>Eros Ramazzotti</ARTIST>
+    <COUNTRY>EU</COUNTRY>
+    <COMPANY>BMG</COMPANY>
+    <PRICE>9.90</PRICE>
+    <YEAR>1997</YEAR>
+  </CD>
+  <CD>
+    <TITLE>One night only</TITLE>
+    <ARTIST>Bee Gees</ARTIST>
+    <COUNTRY>UK</COUNTRY>
+    <COMPANY>Polydor</COMPANY>
+    <PRICE>10.90</PRICE>
+    <YEAR>1998</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Sylvias Mother</TITLE>
+    <ARTIST>Dr.Hook</ARTIST>
+    <COUNTRY>UK</COUNTRY>
+    <COMPANY>CBS</COMPANY>
+    <PRICE>8.10</PRICE>
+    <YEAR>1973</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Maggie May</TITLE>
+    <ARTIST>Rod Stewart</ARTIST>
+    <COUNTRY>UK</COUNTRY>
+    <COMPANY>Pickwick</COMPANY>
+    <PRICE>8.50</PRICE>
+    <YEAR>1990</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Romanza</TITLE>
+    <ARTIST>Andrea Bocelli</ARTIST>
+    <COUNTRY>EU</COUNTRY>
+    <COMPANY>Polydor</COMPANY>
+    <PRICE>10.80</PRICE>
+    <YEAR>1996</YEAR>
+  </CD>
+  <CD>
+    <TITLE>When a man loves a woman</TITLE>
+    <ARTIST>Percy Sledge</ARTIST>
+    <COUNTRY>USA</COUNTRY>
+    <COMPANY>Atlantic</COMPANY>
+    <PRICE>8.70</PRICE>
+    <YEAR>1987</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Black angel</TITLE>
+    <ARTIST>Savage Rose</ARTIST>
+    <COUNTRY>EU</COUNTRY>
+    <COMPANY>Mega</COMPANY>
+    <PRICE>10.90</PRICE>
+    <YEAR>1995</YEAR>
+  </CD>
+  <CD>
+    <TITLE>1999 Grammy Nominees</TITLE>
+    <ARTIST>Many</ARTIST>
+    <COUNTRY>USA</COUNTRY>
+    <COMPANY>Grammy</COMPANY>
+    <PRICE>10.20</PRICE>
+    <YEAR>1999</YEAR>
+  </CD>
+  <CD>
+    <TITLE>For the good times</TITLE>
+    <ARTIST>Kenny Rogers</ARTIST>
+    <COUNTRY>UK</COUNTRY>
+    <COMPANY>Mucik Master</COMPANY>
+    <PRICE>8.70</PRICE>
+    <YEAR>1995</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Big Willie style</TITLE>
+    <ARTIST>Will Smith</ARTIST>
+    <COUNTRY>USA</COUNTRY>
+    <COMPANY>Columbia</COMPANY>
+    <PRICE>9.90</PRICE>
+    <YEAR>1997</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Tupelo Honey</TITLE>
+    <ARTIST>Van Morrison</ARTIST>
+    <COUNTRY>UK</COUNTRY>
+    <COMPANY>Polydor</COMPANY>
+    <PRICE>8.20</PRICE>
+    <YEAR>1971</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Soulsville</TITLE>
+    <ARTIST>Jorn Hoel</ARTIST>
+    <COUNTRY>Norway</COUNTRY>
+    <COMPANY>WEA</COMPANY>
+    <PRICE>7.90</PRICE>
+    <YEAR>1996</YEAR>
+  </CD>
+  <CD>
+    <TITLE>The very best of</TITLE>
+    <ARTIST>Cat Stevens</ARTIST>
+    <COUNTRY>UK</COUNTRY>
+    <COMPANY>Island</COMPANY>
+    <PRICE>8.90</PRICE>
+    <YEAR>1990</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Stop</TITLE>
+    <ARTIST>Sam Brown</ARTIST>
+    <COUNTRY>UK</COUNTRY>
+    <COMPANY>A and M</COMPANY>
+    <PRICE>8.90</PRICE>
+    <YEAR>1988</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Bridge of Spies</TITLE>
+    <ARTIST>T'Pau</ARTIST>
+    <COUNTRY>UK</COUNTRY>
+    <COMPANY>Siren</COMPANY>
+    <PRICE>7.90</PRICE>
+    <YEAR>1987</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Private Dancer</TITLE>
+    <ARTIST>Tina Turner</ARTIST>
+    <COUNTRY>UK</COUNTRY>
+    <COMPANY>Capitol</COMPANY>
+    <PRICE>8.90</PRICE>
+    <YEAR>1983</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Midt om natten</TITLE>
+    <ARTIST>Kim Larsen</ARTIST>
+    <COUNTRY>EU</COUNTRY>
+    <COMPANY>Medley</COMPANY>
+    <PRICE>7.80</PRICE>
+    <YEAR>1983</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Pavarotti Gala Concert</TITLE>
+    <ARTIST>Luciano Pavarotti</ARTIST>
+    <COUNTRY>UK</COUNTRY>
+    <COMPANY>DECCA</COMPANY>
+    <PRICE>9.90</PRICE>
+    <YEAR>1991</YEAR>
+  </CD>
+  <CD>
+    <TITLE>The dock of the bay</TITLE>
+    <ARTIST>Otis Redding</ARTIST>
+    <COUNTRY>USA</COUNTRY>
+    <COMPANY>Stax Records</COMPANY>
+    <PRICE>7.90</PRICE>
+    <YEAR>1968</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Picture book</TITLE>
+    <ARTIST>Simply Red</ARTIST>
+    <COUNTRY>EU</COUNTRY>
+    <COMPANY>Elektra</COMPANY>
+    <PRICE>7.20</PRICE>
+    <YEAR>1985</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Red</TITLE>
+    <ARTIST>The Communards</ARTIST>
+    <COUNTRY>UK</COUNTRY>
+    <COMPANY>London</COMPANY>
+    <PRICE>7.80</PRICE>
+    <YEAR>1987</YEAR>
+  </CD>
+  <CD>
+    <TITLE>Unchain my heart</TITLE>
+    <ARTIST>Joe Cocker</ARTIST>
+    <COUNTRY>USA</COUNTRY>
+    <COMPANY>EMI</COMPANY>
+    <PRICE>8.20</PRICE>
+    <YEAR>1987</YEAR>
+  </CD>
+</CATALOG>

--- a/matchers/test_data/xml/sample_06.xml
+++ b/matchers/test_data/xml/sample_06.xml
@@ -1,0 +1,13 @@
+<root>
+    <table>
+        <tr>
+            <td>Apples</td>
+            <td>Bananas</td>
+        </tr>
+    </table>
+    <table>
+        <name>African Coffee Table</name>
+        <width>80</width>
+        <length>120</length>
+    </table>
+</root>

--- a/matchers/test_data/xml/sample_07.xml
+++ b/matchers/test_data/xml/sample_07.xml
@@ -1,0 +1,13 @@
+<root>
+    <h:table xmlns:h="http://www.w3.org/TR/html4/">
+        <h:tr>
+            <h:td>Apples</h:td>
+            <h:td>Bananas</h:td>
+        </h:tr>
+    </h:table>
+    <f:table xmlns:f="https://www.w3schools.com/furniture">
+        <f:name>African Coffee Table</f:name>
+        <f:width>80</f:width>
+        <f:length>120</f:length>
+    </f:table>
+</root>

--- a/matchers/test_data/xml/sample_08.xml
+++ b/matchers/test_data/xml/sample_08.xml
@@ -1,0 +1,13 @@
+<root>
+    <h:table xmlns:h="http://www.w3.org/TR/html4/">
+        <h:tr>
+            <h:td>Apples</h:td>
+            <h:td>Oranges</h:td>
+        </h:tr>
+    </h:table>
+    <f:table xmlns:f="https://www.w3schools.com/furniture">
+        <f:name>African Coffee Table</f:name>
+        <f:width>80</f:width>
+        <f:length>120</f:length>
+    </f:table>
+</root>

--- a/matchers/test_data/xml/sample_09.xml
+++ b/matchers/test_data/xml/sample_09.xml
@@ -1,0 +1,4 @@
+<person gender="female">
+    <firstname>Foo</firstname>
+    <lastname>Bar</lastname>
+</person>

--- a/matchers/test_data/xml/sample_10.xml
+++ b/matchers/test_data/xml/sample_10.xml
@@ -1,0 +1,4 @@
+<person gender="male">
+    <firstname>Foo</firstname>
+    <lastname>Bar</lastname>
+</person>

--- a/matchers/xml_node_before_go1.8.go
+++ b/matchers/xml_node_before_go1.8.go
@@ -1,0 +1,21 @@
+// +build !go1.8
+
+package matchers
+
+import "encoding/xml"
+
+type xmlNode struct {
+	XMLName xml.Name
+	Content []byte     `xml:",innerxml"`
+	Nodes   []*xmlNode `xml:",any"`
+}
+
+func (n *xmlNode) Clean() {
+	if len(n.Nodes) == 0 {
+		return
+	}
+	n.Content = nil
+	for _, child := range n.Nodes {
+		child.Clean()
+	}
+}

--- a/matchers/xml_node_go1.8.go
+++ b/matchers/xml_node_go1.8.go
@@ -1,0 +1,22 @@
+// +build go1.8
+
+package matchers
+
+import "encoding/xml"
+
+type xmlNode struct {
+	XMLName xml.Name
+	XMLAttr []xml.Attr `xml:",any,attr"`
+	Content []byte     `xml:",innerxml"`
+	Nodes   []*xmlNode `xml:",any"`
+}
+
+func (n *xmlNode) Clean() {
+	if len(n.Nodes) == 0 {
+		return
+	}
+	n.Content = nil
+	for _, child := range n.Nodes {
+		child.Clean()
+	}
+}


### PR DESCRIPTION
Actual and expected can not be pretty printed in the test output because
there are issues in the encoding/xml package related to deplicated
namespaces. See https://github.com/golang/go/issues/7535

Because Go has no support for collecting all XML attributes before 1.8
(see [here](https://github.com/golang/go/commit/c1a1328c5f004c62b8c08faf0d0d2845e0be5d37)), the two following XMLs will be equal for 1.7 and before:

```
<person gender="female">
```

```
<person gender="male">
```