### PR TITLE
Make assertion failures be Fatal

### DIFF
--- a/internal/testingtsupport/testing_t_support.go
+++ b/internal/testingtsupport/testing_t_support.go
@@ -9,7 +9,7 @@ import (
 )
 
 type gomegaTestingT interface {
-	Errorf(format string, args ...interface{})
+	Fatalf(format string, args ...interface{})
 }
 
 func BuildTestingTGomegaFailHandler(t gomegaTestingT) types.GomegaFailHandler {
@@ -19,7 +19,7 @@ func BuildTestingTGomegaFailHandler(t gomegaTestingT) types.GomegaFailHandler {
 			skip = callerSkip[0]
 		}
 		stackTrace := pruneStack(string(debug.Stack()), skip)
-		t.Errorf("\n%s\n%s", stackTrace, message)
+		t.Fatalf("\n%s\n%s", stackTrace, message)
 	}
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -4,7 +4,7 @@ type GomegaFailHandler func(message string, callerSkip ...int)
 
 //A simple *testing.T interface wrapper
 type GomegaTestingT interface {
-	Errorf(format string, args ...interface{})
+	Fatalf(format string, args ...interface{})
 }
 
 //All Gomega matchers must implement the GomegaMatcher interface


### PR DESCRIPTION
When using Gomega with Ginkgo, assertion failures are fatal and halt the current test.
But when Gomega is used by itself in Golang style XUnit tests, assertion failures
do not halt the current test.

This was because t.Errorf was called instead of t.Fatalf.

Fixed to call t.Fatalf instead.