### PR TITLE
Get GOPATH from go internals

### DIFF
--- a/gexec/build.go
+++ b/gexec/build.go
@@ -22,7 +22,8 @@ var (
 Build uses go build to compile the package at packagePath.  The resulting binary is saved off in a temporary directory.
 A path pointing to this binary is returned.
 
-Build uses the $GOPATH set in your environment.  It passes the variadic args on to `go build`.
+Build uses the $GOPATH set in your environment. If $GOPATH is not set and you are using Go 1.8+, 
+$HOME/go directory is used instead.  It passes the variadic args on to `go build`.
 */
 func Build(packagePath string, args ...string) (compiledPath string, err error) {
 	return doBuild(build.Default.GOPATH, packagePath, nil, args...)

--- a/gexec/build.go
+++ b/gexec/build.go
@@ -3,6 +3,7 @@ package gexec
 import (
 	"errors"
 	"fmt"
+        "go/build"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -24,14 +25,14 @@ A path pointing to this binary is returned.
 Build uses the $GOPATH set in your environment.  It passes the variadic args on to `go build`.
 */
 func Build(packagePath string, args ...string) (compiledPath string, err error) {
-	return doBuild(os.Getenv("GOPATH"), packagePath, nil, args...)
+	return doBuild(build.Default.GOPATH, packagePath, nil, args...)
 }
 
 /*
 BuildWithEnvironment is identical to Build but allows you to specify env vars to be set at build time.
 */
 func BuildWithEnvironment(packagePath string, env []string, args ...string) (compiledPath string, err error) {
-	return doBuild(os.Getenv("GOPATH"), packagePath, env, args...)
+	return doBuild(build.Default.GOPATH, packagePath, env, args...)
 }
 
 /*

--- a/gexec/build.go
+++ b/gexec/build.go
@@ -23,7 +23,7 @@ Build uses go build to compile the package at packagePath.  The resulting binary
 A path pointing to this binary is returned.
 
 Build uses the $GOPATH set in your environment. If $GOPATH is not set and you are using Go 1.8+, 
-$HOME/go directory is used instead.  It passes the variadic args on to `go build`.
+it will use the default GOPATH instead.  It passes the variadic args on to `go build`.
 */
 func Build(packagePath string, args ...string) (compiledPath string, err error) {
 	return doBuild(build.Default.GOPATH, packagePath, nil, args...)


### PR DESCRIPTION
Starting Go 1.8 GOPATH is not required and has default value to `$HOME/go`.
https://golang.org/doc/go1.8#gopath
This change supports this behavior.