### PR TITLE
Added a matcher for json to allow for unordered lists

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -214,6 +214,16 @@ func MatchJSON(json interface{}) types.GomegaMatcher {
 	}
 }
 
+//MatchUnorderedJSON succeeds if actual is a string or stringer of JSON that matches
+//the expected JSON, however all arrays are treeted as un-ordered.
+//The JSONs are decoded and the resulting objects are compared via
+//reflect.DeepEqual so things like key-ordering and whitespace shouldn't matter.
+func MatchUnorderedJSON(json interface{}) types.GomegaMatcher {
+	return &matchers.MatchUnorderedJSONMatcher{
+		JSONToMatch: json,
+	}
+}
+
 //MatchYAML succeeds if actual is a string or stringer of YAML that matches
 //the expected YAML.  The YAML's are decoded and the resulting objects are compared via
 //reflect.DeepEqual so things like key-ordering and whitespace shouldn't matter.

--- a/matchers/match_unordered_json_matcher.go
+++ b/matchers/match_unordered_json_matcher.go
@@ -59,32 +59,6 @@ func (matcher *MatchUnorderedJSONMatcher) NegatedFailureMessage(actual interface
 	return formattedMessage(format.Message(actualString, "not to match JSON of", expectedString), matcher.firstFailurePath)
 }
 
-func formattedMessage(comparisonMessage string, failurePath []interface{}) string {
-	var diffMessage string
-	if len(failurePath) == 0 {
-		diffMessage = ""
-	} else {
-		diffMessage = fmt.Sprintf("\n\nfirst mismatched key: %s", formattedFailurePath(failurePath))
-	}
-	return fmt.Sprintf("%s%s", comparisonMessage, diffMessage)
-}
-
-func formattedFailurePath(failurePath []interface{}) string {
-	formattedPaths := []string{}
-	for i := len(failurePath) - 1; i >= 0; i-- {
-		switch p := failurePath[i].(type) {
-		case int:
-			formattedPaths = append(formattedPaths, fmt.Sprintf(`[%d]`, p))
-		default:
-			if i != len(failurePath)-1 {
-				formattedPaths = append(formattedPaths, ".")
-			}
-			formattedPaths = append(formattedPaths, fmt.Sprintf(`"%s"`, p))
-		}
-	}
-	return strings.Join(formattedPaths, "")
-}
-
 func (matcher *MatchUnorderedJSONMatcher) prettyPrint(actual interface{}) (actualFormatted, expectedFormatted string, err error) {
 	actualString, ok := toString(actual)
 	if !ok {

--- a/matchers/match_unordered_json_matcher.go
+++ b/matchers/match_unordered_json_matcher.go
@@ -1,0 +1,188 @@
+package matchers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+)
+
+func WithOrderedKeys(maybeMatcher types.GomegaMatcher, keys ...string) types.GomegaMatcher{
+	matcher, ok := maybeMatcher.(*MatchUnorderedJSONMatcher)
+	if !ok{
+		panic("Matcher must be of type MatchUnorderedJSONMatcher")
+	}
+	matcher.OrderedKeys = make(map[string]bool)
+	for _, v  := range keys {
+		matcher.OrderedKeys[v] = true
+	}
+	return matcher
+
+}
+
+type MatchUnorderedJSONMatcher struct {
+	JSONToMatch      interface{}
+	firstFailurePath []interface{}
+	OrderedKeys      map[string]bool
+}
+
+func (matcher *MatchUnorderedJSONMatcher) Match(actual interface{}) (success bool, err error) {
+	actualString, expectedString, err := matcher.prettyPrint(actual)
+	if err != nil {
+		return false, err
+	}
+
+	var aval interface{}
+	var eval interface{}
+
+	// this is guarded by prettyPrint
+	json.Unmarshal([]byte(actualString), &aval)
+	json.Unmarshal([]byte(expectedString), &eval)
+	var equal bool
+
+
+	equal, matcher.firstFailurePath = matcher.deepEqual(aval, eval, false)
+	return equal, nil
+}
+
+func (matcher *MatchUnorderedJSONMatcher) FailureMessage(actual interface{}) (message string) {
+	actualString, expectedString, _ := matcher.prettyPrint(actual)
+	return formattedMessage(format.Message(actualString, "to match JSON of", expectedString), matcher.firstFailurePath)
+}
+
+func (matcher *MatchUnorderedJSONMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	actualString, expectedString, _ := matcher.prettyPrint(actual)
+	return formattedMessage(format.Message(actualString, "not to match JSON of", expectedString), matcher.firstFailurePath)
+}
+
+func formattedMessage(comparisonMessage string, failurePath []interface{}) string {
+	var diffMessage string
+	if len(failurePath) == 0 {
+		diffMessage = ""
+	} else {
+		diffMessage = fmt.Sprintf("\n\nfirst mismatched key: %s", formattedFailurePath(failurePath))
+	}
+	return fmt.Sprintf("%s%s", comparisonMessage, diffMessage)
+}
+
+func formattedFailurePath(failurePath []interface{}) string {
+	formattedPaths := []string{}
+	for i := len(failurePath) - 1; i >= 0; i-- {
+		switch p := failurePath[i].(type) {
+		case int:
+			formattedPaths = append(formattedPaths, fmt.Sprintf(`[%d]`, p))
+		default:
+			if i != len(failurePath)-1 {
+				formattedPaths = append(formattedPaths, ".")
+			}
+			formattedPaths = append(formattedPaths, fmt.Sprintf(`"%s"`, p))
+		}
+	}
+	return strings.Join(formattedPaths, "")
+}
+
+func (matcher *MatchUnorderedJSONMatcher) prettyPrint(actual interface{}) (actualFormatted, expectedFormatted string, err error) {
+	actualString, ok := toString(actual)
+	if !ok {
+		return "", "", fmt.Errorf("MatchUnorderedJSONMatcher matcher requires a string, stringer, or []byte.  Got actual:\n%s", format.Object(actual, 1))
+	}
+	expectedString, ok := toString(matcher.JSONToMatch)
+	if !ok {
+		return "", "", fmt.Errorf("MatchUnorderedJSONMatcher matcher requires a string, stringer, or []byte.  Got expected:\n%s", format.Object(matcher.JSONToMatch, 1))
+	}
+
+	abuf := new(bytes.Buffer)
+	ebuf := new(bytes.Buffer)
+
+	if err := json.Indent(abuf, []byte(actualString), "", "  "); err != nil {
+		return "", "", fmt.Errorf("Actual '%s' should be valid JSON, but it is not.\nUnderlying error:%s", actualString, err)
+	}
+
+	if err := json.Indent(ebuf, []byte(expectedString), "", "  "); err != nil {
+		return "", "", fmt.Errorf("Expected '%s' should be valid JSON, but it is not.\nUnderlying error:%s", expectedString, err)
+	}
+
+	return abuf.String(), ebuf.String(), nil
+}
+
+func (matcher *MatchUnorderedJSONMatcher) deepEqual(a interface{}, b interface{}, ordered bool) (bool, []interface{}) {
+	var errorPath []interface{}
+	if reflect.TypeOf(a) != reflect.TypeOf(b) {
+		return false, errorPath
+	}
+
+	switch a.(type) {
+	case []interface{}:
+		if ordered {
+			return matcher.deepEqualOrderedList(a, b, errorPath)
+		} else {
+			return matcher.deepEqualUnorderedList(a, b, errorPath)
+		}
+
+	case map[string]interface{}:
+		if len(a.(map[string]interface{})) != len(b.(map[string]interface{})) {
+			return false, errorPath
+		}
+
+		for k, v1 := range a.(map[string]interface{}) {
+			v2, ok := b.(map[string]interface{})[k]
+			if !ok {
+				return false, errorPath
+			}
+
+			elementEqual, keyPath := matcher.deepEqual(v1, v2, matcher.OrderedKeys[k])
+			if !elementEqual {
+				return false, append(keyPath, k)
+			}
+		}
+		return true, errorPath
+
+	default:
+		return a == b, errorPath
+	}
+}
+
+func (matcher *MatchUnorderedJSONMatcher) deepEqualUnorderedList(a interface{}, b interface{}, errorPath []interface{}) (bool, []interface{}) {
+	if len(a.([]interface{})) != len(b.([]interface{})) {
+		return false, errorPath
+	}
+	matched := make([]bool, len(b.([]interface{})))
+
+	for _, v1 := range a.([]interface{}) {
+		foundMatch := false
+		for j, v2 := range b.([]interface{}) {
+			if matched[j] {
+				continue
+			}
+			elementEqual, _ := matcher.deepEqual(v1, v2, false)
+			if elementEqual {
+				foundMatch = true
+				matched[j] = true
+				break
+			}
+		}
+		if !foundMatch {
+			return false, errorPath
+		}
+	}
+
+	return true, errorPath
+}
+
+func (matcher *MatchUnorderedJSONMatcher) deepEqualOrderedList(a interface{}, b interface{}, errorPath []interface{}) (bool, []interface{}) {
+	if len(a.([]interface{})) != len(b.([]interface{})) {
+		return false, errorPath
+	}
+
+	for i, v := range a.([]interface{}) {
+		elementEqual, keyPath := matcher.deepEqual(v, b.([]interface{})[i], false)
+		if !elementEqual {
+			return false, append(keyPath, i)
+		}
+	}
+	return true, errorPath
+}

--- a/matchers/match_unordered_json_matcher.go
+++ b/matchers/match_unordered_json_matcher.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"

--- a/matchers/match_unordered_json_matcher_test.go
+++ b/matchers/match_unordered_json_matcher_test.go
@@ -1,0 +1,134 @@
+package matchers_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/matchers"
+)
+
+var _ = Describe("MatchUnorderedJSONMatcher", func() {
+	Context("When passed stringifiables", func() {
+		It("should succeed if the JSON matches", func() {
+			Ω("{}").Should(MatchUnorderedJSON("{}"))
+			Ω(`{"a":1}`).Should(MatchUnorderedJSON(`{"a":1}`))
+			Ω(`{
+			             "a":1
+			         }`).Should(MatchUnorderedJSON(`{"a":1}`))
+			Ω(`{"a":1, "b":2}`).Should(MatchUnorderedJSON(`{"b":2, "a":1}`))
+			Ω(`{"a":1}`).ShouldNot(MatchUnorderedJSON(`{"b":2, "a":1}`))
+
+			Ω(`{"a":"a", "b":"b"}`).ShouldNot(MatchUnorderedJSON(`{"a":"a", "b":"b", "c":"c"}`))
+			Ω(`{"a":"a", "b":"b", "c":"c"}`).ShouldNot(MatchUnorderedJSON(`{"a":"a", "b":"b"}`))
+
+			Ω(`{"a":null, "b":null}`).ShouldNot(MatchUnorderedJSON(`{"c":"c", "d":"d"}`))
+			Ω(`{"a":null, "b":null, "c":null}`).ShouldNot(MatchUnorderedJSON(`{"a":null, "b":null, "d":null}`))
+		})
+
+		It("should work with byte arrays", func() {
+			Ω([]byte("{}")).Should(MatchUnorderedJSON([]byte("{}")))
+			Ω("{}").Should(MatchUnorderedJSON([]byte("{}")))
+			Ω([]byte("{}")).Should(MatchUnorderedJSON("{}"))
+		})
+	})
+
+	Context("When there are arrays that are unordered", func() {
+		It("should succeed if the JSON matches", func() {
+			Ω(`{"a":[1,2,3]}`).Should(MatchUnorderedJSON(`{"a":[3,2,1]}`))
+			Ω(`{"a":[1,2,3],"b":[1,2,3],"c":[1,2,3]}`).Should(MatchUnorderedJSON(`{"a":[3,2,1],"b":[3,2,1],"c":[3,2,1]}`))
+			Ω(`[[1,2,3],[4,5,6],[7,8,9]]`).Should(MatchUnorderedJSON(`[[9,8,7],[6,5,4],[3,2,1]]`))
+			Ω(`[[1,2,3],[1,2,3],[1,2,3]]`).Should(MatchUnorderedJSON(`[[3,2,1],[3,2,1],[3,2,1]]`))
+		})
+	})
+
+	Context("When some of the keys are ordered", func() {
+		It("should succeed if the JSON matches", func() {
+			Ω(`{"a":[1,2,3],"b":[1,2,3],"c":[1,2,3]}`).Should(WithOrderedKeys(MatchUnorderedJSON(`{"a":[1,2,3],"b":[3,2,1],"c":[3,2,1]}`), "a"))
+		})
+
+		It("should not succeed if a ordered key doesn't match", func (){
+			Ω(`{"a":[1,2,3],"b":[1,2,3],"c":[1,2,3]}`).ShouldNot(WithOrderedKeys(MatchUnorderedJSON(`{"a":[3,2,1],"b":[3,2,1],"c":[3,2,1]}`), "a"))
+		})
+	})
+
+
+
+	Context("when a key mismatch is found", func() {
+		It("reports the first found mismatch", func() {
+			subject := MatchUnorderedJSONMatcher{JSONToMatch: `5`}
+			actual := `7`
+			subject.Match(actual)
+
+			failureMessage := subject.FailureMessage(`7`)
+			Ω(failureMessage).ToNot(ContainSubstring("first mismatched key"))
+
+			subject = MatchUnorderedJSONMatcher{JSONToMatch: `{"a": 1, "b.g": {"c": 2, "1": ["hello", "see ya"]}}`}
+			actual = `{"a": 1, "b.g": {"c": 2, "1": ["hello", "goodbye"]}}`
+			subject.Match(actual)
+
+			failureMessage = subject.FailureMessage(actual)
+			Ω(failureMessage).To(ContainSubstring(`first mismatched key: "b.g"."1"`))//Only report on the array, not the index
+		})
+
+		It("reports the first found mismatch as Json does when the key is ordered", func() {
+			subject := MatchUnorderedJSONMatcher{JSONToMatch: `5`}
+			actual := `7`
+			subject.Match(actual)
+
+			failureMessage := subject.FailureMessage(`7`)
+			Ω(failureMessage).ToNot(ContainSubstring("first mismatched key"))
+
+			subject = MatchUnorderedJSONMatcher{JSONToMatch: `{"a": 1, "b.g": {"c": 2, "1": ["hello", "see ya"]}}`, OrderedKeys: map[string]bool{"1":true}  }
+			actual = `{"a": 1, "b.g": {"c": 2, "1": ["hello", "goodbye"]}}`
+			subject.Match(actual)
+
+			failureMessage = subject.FailureMessage(actual)
+			Ω(failureMessage).To(ContainSubstring(`first mismatched key: "b.g"."1"[1]`))
+		})
+	})
+
+	Context("when the expected is not valid JSON", func() {
+		It("should error and explain why", func() {
+			success, err := (&MatchUnorderedJSONMatcher{JSONToMatch: `{}`}).Match(`oops`)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring("Actual 'oops' should be valid JSON"))
+		})
+	})
+
+	Context("when the actual is not valid JSON", func() {
+		It("should error and explain why", func() {
+			success, err := (&MatchUnorderedJSONMatcher{JSONToMatch: `oops`}).Match(`{}`)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring("Expected 'oops' should be valid JSON"))
+		})
+	})
+
+	Context("when the expected is neither a string nor a stringer nor a byte array", func() {
+		It("should error", func() {
+			success, err := (&MatchUnorderedJSONMatcher{JSONToMatch: 2}).Match("{}")
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring("MatchUnorderedJSONMatcher matcher requires a string, stringer, or []byte.  Got expected:\n    <int>: 2"))
+
+			success, err = (&MatchUnorderedJSONMatcher{JSONToMatch: nil}).Match("{}")
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring("MatchUnorderedJSONMatcher matcher requires a string, stringer, or []byte.  Got expected:\n    <nil>: nil"))
+		})
+	})
+
+	Context("when the actual is neither a string nor a stringer nor a byte array", func() {
+		It("should error", func() {
+			success, err := (&MatchUnorderedJSONMatcher{JSONToMatch: "{}"}).Match(2)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring("MatchUnorderedJSONMatcher matcher requires a string, stringer, or []byte.  Got actual:\n    <int>: 2"))
+
+			success, err = (&MatchUnorderedJSONMatcher{JSONToMatch: "{}"}).Match(nil)
+			Ω(success).Should(BeFalse())
+			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring("MatchUnorderedJSONMatcher matcher requires a string, stringer, or []byte.  Got actual:\n    <nil>: nil"))
+		})
+	})
+})


### PR DESCRIPTION
Often you want to match against json but you don't know, or care what order a particular list is in. In this case, you might rely on MatchUnorderedJson. It treats all the lists in the son as unordered. If you want to have ordered keys, you can exclude them by using the OrderedKeys(matcher, keys) function to exclude some son keys from it's un-ordered grasp. 

As far as the tests, I just copied the regular json matcher tests(As they all should work) as well as some unordered tests(as they should also work). If you like this, I could add a "UnorderedKeys" function that operates on the MatchJson function to allow for some lists to be un-ordered. 

A co-worker suggested I make the code more "readable" when use, that's the reasoning behind using OrderedKeys(matcher, keys) instead of matcher(json, keys). 

If you like this, I can add the functionality/refactor this to matchXML and matchYML. 

Does any of this sound like a good idea/something you want in the base library? 