### PR TITLE
implement a shortcut for byte slices in the Equal matcher

### DIFF
--- a/matchers/equal_matcher_test.go
+++ b/matchers/equal_matcher_test.go
@@ -31,6 +31,8 @@ var _ = Describe("Equal", func() {
 			Ω("5").Should(Equal("5"))
 			Ω([]int{1, 2}).Should(Equal([]int{1, 2}))
 			Ω([]int{1, 2}).ShouldNot(Equal([]int{2, 1}))
+			Ω([]byte{'f', 'o', 'o'}).Should(Equal([]byte{'f', 'o', 'o'}))
+			Ω([]byte{'f', 'o', 'o'}).ShouldNot(Equal([]byte{'b', 'a', 'r'}))
 			Ω(map[string]string{"a": "b", "c": "d"}).Should(Equal(map[string]string{"a": "b", "c": "d"}))
 			Ω(map[string]string{"a": "b", "c": "d"}).ShouldNot(Equal(map[string]string{"a": "b", "c": "e"}))
 			Ω(errors.New("foo")).Should(Equal(errors.New("foo")))


### PR DESCRIPTION
`reflect.DeepEqual` is very slow for larger byte slices. This PR adds a type assertion on the actual and expected values in the `Equal` matcher, and uses `bytes.Equal` if both of them are byte slices.

In the [quic-go](https://github.com/lucas-clemente/quic-go/) tests, we're using `Equal` to compare 50 MB of data in multiple tests. On my computer, `reflect.DeepEqual` takes about 5s for this amount of data, whereas `bytes.Equal` returns within a couple of milliseconds.