### PR TITLE
MatchErrorMatcher strings that are errors fix

### DIFF
--- a/matchers/match_error_matcher.go
+++ b/matchers/match_error_matcher.go
@@ -22,12 +22,12 @@ func (matcher *MatchErrorMatcher) Match(actual interface{}) (success bool, err e
 
 	actualErr := actual.(error)
 
-	if isString(matcher.Expected) {
-		return actualErr.Error() == matcher.Expected, nil
-	}
-
 	if isError(matcher.Expected) {
 		return reflect.DeepEqual(actualErr, matcher.Expected), nil
+	}
+
+	if isString(matcher.Expected) {
+		return actualErr.Error() == matcher.Expected, nil
 	}
 
 	var subMatcher omegaMatcher

--- a/matchers/match_error_matcher_test.go
+++ b/matchers/match_error_matcher_test.go
@@ -90,4 +90,16 @@ var _ = Describe("MatchErrorMatcher", func() {
 			Ω(err).Should(HaveOccurred())
 		})
 	})
+
+	Context("when passed an error that is also a string", func() {
+		It("should use it as an error", func() {
+			var e mockErr = "mockErr"
+
+			// this fails if the matcher casts e to a string before comparison
+			Ω(e).Should(MatchError(e))
+		})
+	})
 })
+
+type mockErr string
+func (m mockErr) Error() string {return string(m)}


### PR DESCRIPTION
Swapped the error and string checks in the MatchErrorMatcher.Match method.
This allows named string types that are also errors to properly be matched against themselves.
Added a test to validate the expected behavior, which fails without the swap of the checks.
Fixes #232