### PR TITLE
Do no assume that writers are always pointers

### DIFF
--- a/gexec/session.go
+++ b/gexec/session.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"reflect"
 	"sync"
 	"syscall"
 
@@ -78,11 +77,11 @@ func Start(command *exec.Cmd, outWriter io.Writer, errWriter io.Writer) (*Sessio
 
 	commandOut, commandErr = session.Out, session.Err
 
-	if outWriter != nil && !reflect.ValueOf(outWriter).IsNil() {
+	if outWriter != nil {
 		commandOut = io.MultiWriter(commandOut, outWriter)
 	}
 
-	if errWriter != nil && !reflect.ValueOf(errWriter).IsNil() {
+	if errWriter != nil {
 		commandErr = io.MultiWriter(commandErr, errWriter)
 	}
 

--- a/gexec/session_test.go
+++ b/gexec/session_test.go
@@ -2,6 +2,7 @@ package gexec_test
 
 import (
 	"io"
+	"io/ioutil"
 	"os/exec"
 	"syscall"
 	"time"
@@ -324,7 +325,10 @@ var _ = Describe("Session", func() {
 	})
 
 	Context("when wrapping out and err", func() {
-		var outWriterBuffer, errWriterBuffer *Buffer
+		var (
+			outWriterBuffer, errWriterBuffer *Buffer
+		)
+
 		BeforeEach(func() {
 			outWriterBuffer = NewBuffer()
 			outWriter = outWriterBuffer
@@ -343,6 +347,17 @@ var _ = Describe("Session", func() {
 
 			Ω(outWriterBuffer.Contents()).Should(Equal(session.Out.Contents()))
 			Ω(errWriterBuffer.Contents()).Should(Equal(session.Err.Contents()))
+		})
+
+		Context("when discarding the output of the command", func() {
+			BeforeEach(func() {
+				outWriter = ioutil.Discard
+				errWriter = ioutil.Discard
+			})
+
+			It("executes succesfuly", func() {
+				Eventually(session).Should(Exit())
+			})
 		})
 	})
 

--- a/gexec/session_test.go
+++ b/gexec/session_test.go
@@ -1,6 +1,7 @@
 package gexec_test
 
 import (
+	"io"
 	"os/exec"
 	"syscall"
 	"time"
@@ -16,7 +17,7 @@ var _ = Describe("Session", func() {
 	var command *exec.Cmd
 	var session *Session
 
-	var outWriter, errWriter *Buffer
+	var outWriter, errWriter io.Writer
 
 	BeforeEach(func() {
 		outWriter = nil
@@ -323,22 +324,25 @@ var _ = Describe("Session", func() {
 	})
 
 	Context("when wrapping out and err", func() {
+		var outWriterBuffer, errWriterBuffer *Buffer
 		BeforeEach(func() {
-			outWriter = NewBuffer()
-			errWriter = NewBuffer()
+			outWriterBuffer = NewBuffer()
+			outWriter = outWriterBuffer
+			errWriterBuffer = NewBuffer()
+			errWriter = errWriterBuffer
 		})
 
 		It("should route to both the provided writers and the gbytes buffers", func() {
 			Eventually(session.Out).Should(Say("We've done the impossible, and that makes us mighty"))
 			Eventually(session.Err).Should(Say("Ah, curse your sudden but inevitable betrayal!"))
 
-			Ω(outWriter.Contents()).Should(ContainSubstring("We've done the impossible, and that makes us mighty"))
-			Ω(errWriter.Contents()).Should(ContainSubstring("Ah, curse your sudden but inevitable betrayal!"))
+			Ω(outWriterBuffer.Contents()).Should(ContainSubstring("We've done the impossible, and that makes us mighty"))
+			Ω(errWriterBuffer.Contents()).Should(ContainSubstring("Ah, curse your sudden but inevitable betrayal!"))
 
 			Eventually(session).Should(Exit())
 
-			Ω(outWriter.Contents()).Should(Equal(session.Out.Contents()))
-			Ω(errWriter.Contents()).Should(Equal(session.Err.Contents()))
+			Ω(outWriterBuffer.Contents()).Should(Equal(session.Out.Contents()))
+			Ω(errWriterBuffer.Contents()).Should(Equal(session.Err.Contents()))
 		})
 	})
 


### PR DESCRIPTION
This can be the case if the user passes ioutil.Discard as the
writer. ioutil.Discard is just a primitive type (int) which will cause
Value.IsNil to panic

fixes #227