### PR TITLE
Add methods to terminate/kill sessions and wait

### DIFF
--- a/gexec/session.go
+++ b/gexec/session.go
@@ -160,6 +160,19 @@ func (s *Session) Kill() *Session {
 }
 
 /*
+KillAndWait sends the running command a SIGKILL signal.  It waits for the process to exit.
+
+If the command has already exited, Kill returns silently.
+
+KillAndWait uses Kill and Wait under the hood and accepts the same timeout/polling intervals that Wait does.
+
+The session is returned to enable chaining.
+*/
+func (s *Session) KillAndWait(timeout ...interface{}) *Session {
+	return s.Kill().Wait(timeout...)
+}
+
+/*
 Interrupt sends the running command a SIGINT signal.  It does not wait for the process to exit.
 
 If the command has already exited, Interrupt returns silently.
@@ -179,6 +192,19 @@ The session is returned to enable chaining.
 */
 func (s *Session) Terminate() *Session {
 	return s.Signal(syscall.SIGTERM)
+}
+
+/*
+TerminateAndWait sends the running command a SIGTERM signal.  It waits for the process to exit.
+
+If the command has already exited, Terminate returns silently.
+
+TerminateAndWait uses Terminate and Wait under the hood and accepts the same timeout/polling intervals that Wait does.
+
+The session is returned to enable chaining.
+*/
+func (s *Session) TerminateAndWait(timeout ...interface{}) *Session {
+	return s.Terminate().Wait(timeout...)
 }
 
 /*

--- a/gexec/session_test.go
+++ b/gexec/session_test.go
@@ -94,6 +94,17 @@ var _ = Describe("Session", func() {
 		})
 	})
 
+	Describe("killAndWait", func() {
+		It("should kill the command and wait for it to exit", func() {
+			session, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			newSession := session.KillAndWait()
+			Ω(session).Should(Exit(128 + 9), "Should exit immediately...")
+			Ω(newSession).Should(BeIdenticalTo(session))
+		})
+	})
+
 	Describe("interrupt", func() {
 		It("should interrupt the command", func() {
 			session, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
@@ -113,6 +124,17 @@ var _ = Describe("Session", func() {
 			session.Terminate()
 			Ω(session).ShouldNot(Exit(), "Should not exit immediately...")
 			Eventually(session).Should(Exit(128 + 15))
+		})
+	})
+
+	Describe("terminateAndWait", func() {
+		It("should terminate the command and wait for it to terminate", func() {
+			session, err := Start(exec.Command("sleep", "10000000"), GinkgoWriter, GinkgoWriter)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			newSession := session.TerminateAndWait()
+			Ω(session).Should(Exit(128 + 15), "Should exit immediately...")
+			Ω(newSession).Should(BeIdenticalTo(session))
 		})
 	})
 


### PR DESCRIPTION
Added new methods for sessions to kill resp. terminate them and wait for
that to actually happen:
- KillAndWait
- TerminateAndWait

Main incentive for those is to make it a bit easier to implement parts
of the gexec.Session interface -- to fake certain aspects of it, without the
need of that fake to know about gexec.Session.