### PR TITLE
Fix typos in matcher documentation

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -269,7 +269,7 @@ func ContainElement(element interface{}) types.GomegaMatcher {
 	}
 }
 
-//ConsistOf succeeds if actual contains preciely the elements passed into the matcher.  The ordering of the elements does not matter.
+//ConsistOf succeeds if actual contains precisely the elements passed into the matcher.  The ordering of the elements does not matter.
 //By default ConsistOf() uses Equal() to match the elements, however custom matchers can be passed in instead.  Here are some examples:
 //
 //    Ω([]string{"Foo", "FooBar"}).Should(ConsistOf("FooBar", "Foo"))

--- a/matchers.go
+++ b/matchers.go
@@ -372,7 +372,7 @@ func BeARegularFile() types.GomegaMatcher {
 	return &matchers.BeARegularFileMatcher{}
 }
 
-//BeADirectory succeeds iff a file exists and is a directory.
+//BeADirectory succeeds if a file exists and is a directory.
 //Actual must be a string representing the abs path to the file being checked.
 func BeADirectory() types.GomegaMatcher {
 	return &matchers.BeADirectoryMatcher{}

--- a/matchers.go
+++ b/matchers.go
@@ -366,7 +366,7 @@ func BeAnExistingFile() types.GomegaMatcher {
 	return &matchers.BeAnExistingFileMatcher{}
 }
 
-//BeARegularFile succeeds iff a file exists and is a regular file.
+//BeARegularFile succeeds if a file exists and is a regular file.
 //Actual must be a string representing the abs path to the file being checked.
 func BeARegularFile() types.GomegaMatcher {
 	return &matchers.BeARegularFileMatcher{}


### PR DESCRIPTION
I found a couple typos in the docs. Thanks for making Ginkgo and Gomega!