### PR TITLE
Fix `go vet` issues to prepare to Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
   - go get github.com/onsi/ginkgo
   - go install github.com/onsi/ginkgo/ginkgo
 
-script: $HOME/gopath/bin/ginkgo -p -r --randomizeAllSpecs --failOnPending --randomizeSuites --race
+script: $HOME/gopath/bin/ginkgo -p -r --randomizeAllSpecs --failOnPending --randomizeSuites --race && go vet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Your contributions to Gomega are essential for its long-term maintenance and imp
 - Ensure adequate test coverage:
     - Make sure to add appropriate unit tests
     - Please run all tests locally (`ginkgo -r -p`) and make sure they go green before submitting the PR
+    - Please run following linter locally `go vet ./...` and make sure output does not contain any warnings
 - Update the documentation.  In addition to standard `godoc` comments Gomega has extensive documentation on the `gh-pages` branch.  If relevant, please submit a docs PR to that branch alongside your code PR.
 
 Thanks for supporting Gomega!

--- a/matchers/support/goraph/bipartitegraph/bipartitegraph.go
+++ b/matchers/support/goraph/bipartitegraph/bipartitegraph.go
@@ -15,12 +15,12 @@ type BipartiteGraph struct {
 func NewBipartiteGraph(leftValues, rightValues []interface{}, neighbours func(interface{}, interface{}) (bool, error)) (*BipartiteGraph, error) {
 	left := NodeOrderedSet{}
 	for i, _ := range leftValues {
-		left = append(left, Node{i})
+		left = append(left, Node{Id: i})
 	}
 
 	right := NodeOrderedSet{}
 	for j, _ := range rightValues {
-		right = append(right, Node{j + len(left)})
+		right = append(right, Node{Id: j + len(left)})
 	}
 
 	edges := EdgeSet{}
@@ -32,7 +32,7 @@ func NewBipartiteGraph(leftValues, rightValues []interface{}, neighbours func(in
 			}
 
 			if neighbours {
-				edges = append(edges, Edge{left[i], right[j]})
+				edges = append(edges, Edge{Node1: left[i], Node2: right[j]})
 			}
 		}
 	}


### PR DESCRIPTION
Go 1.9 runs `go vet` with `go test`