### PR TITLE
Update panic message to help users debug

### DIFF
--- a/gomega_dsl.go
+++ b/gomega_dsl.go
@@ -29,6 +29,7 @@ const GOMEGA_VERSION = "1.2.0"
 const nilFailHandlerPanic = `You are trying to make an assertion, but Gomega's fail handler is nil.
 If you're using Ginkgo then you probably forgot to put your assertion in an It().
 Alternatively, you may have forgotten to register a fail handler with RegisterFailHandler() or RegisterTestingT().
+Depending on your vendoring solution you may be inadvertently importing gomega and subpackages (e.g. ghhtp, gexec,...) from different locations.
 `
 
 var globalFailHandler types.GomegaFailHandler


### PR DESCRIPTION
I ran into an issue where ghttp was on my gopath, but gomega was vendored. This resulted in my tests passing unexpectedly, and it was difficult for me to trace it back to the source of the problem.