### PR TITLE
Fix link to documentation on adding your own matchers

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -9,7 +9,7 @@ type GomegaTestingT interface {
 
 //All Gomega matchers must implement the GomegaMatcher interface
 //
-//For details on writing custom matchers, check out: http://onsi.github.io/gomega/#adding_your_own_matchers
+//For details on writing custom matchers, check out: http://onsi.github.io/gomega/#adding-your-own-matchers
 type GomegaMatcher interface {
 	Match(actual interface{}) (success bool, err error)
 	FailureMessage(actual interface{}) (message string)


### PR DESCRIPTION
Fixes #269 

The build is failing for this, however it also fails for current master for me:

* my commit: https://travis-ci.org/Patagonicus/gomega/builds/342325851
* commit it is based on: https://travis-ci.org/Patagonicus/gomega/builds/342325295

As this only a change in documentation I doubt that this will make any tests fail.