### PR TITLE
Make string pretty diff user configurable

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -30,6 +30,9 @@ Set PrintContextObjects = true to enable printing of the context internals.
 */
 var PrintContextObjects = false
 
+// TruncatedDiff choose if we should display a truncated pretty diff or not
+var TruncatedDiff = true
+
 // Ctx interface defined here to keep backwards compatability with go < 1.7
 // It matches the context.Context interface
 type Ctx interface {
@@ -82,7 +85,7 @@ to equal               |
 */
 
 func MessageWithDiff(actual, message, expected string) string {
-	if len(actual) >= truncateThreshold && len(expected) >= truncateThreshold {
+	if TruncatedDiff && len(actual) >= truncateThreshold && len(expected) >= truncateThreshold {
 		diffPoint := findFirstMismatch(actual, expected)
 		formattedActual := truncateAndFormat(actual, diffPoint)
 		formattedExpected := truncateAndFormat(expected, diffPoint)

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -166,6 +166,23 @@ var _ = Describe("Format", func() {
 
 			Expect(MessageWithDiff(stringA, "to equal", stringB)).Should(Equal(expectedTruncatedMultiByteFailureMessage))
 		})
+
+		Context("With truncated diff disabled", func() {
+			BeforeEach(func() {
+				TruncatedDiff = false
+			})
+
+			AfterEach(func() {
+				TruncatedDiff = true
+			})
+
+			It("should show the full diff", func() {
+				stringWithB := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+				stringWithZ := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaazaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+				Expect(MessageWithDiff(stringWithB, "to equal", stringWithZ)).Should(Equal(expectedFullFailureDiff))
+			})
+		})
 	})
 
 	Describe("IndentString", func() {
@@ -600,4 +617,11 @@ Expected
     <string>: "...tuvwxyz1"
 to equal                 |
     <string>: "...tuvwxyz"
+`)
+
+var expectedFullFailureDiff = strings.TrimSpace(`
+Expected
+    <string>: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+to equal
+    <string>: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaazaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `)


### PR DESCRIPTION
Let the user set `format.TruncatedDiff = false` if he wants to display the full strings to get more informations about an equality failure.

Fix #192

Doc PR: https://github.com/onsi/gomega/pull/274