### PR TITLE
Use httputil.DumpRequest to pretty-print unhandled requests

### DIFF
--- a/ghttp/test_server.go
+++ b/ghttp/test_server.go
@@ -111,6 +111,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
 	"reflect"
 	"regexp"
 	"strings"
@@ -265,7 +266,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			req.Body.Close()
 			w.WriteHeader(s.GetUnhandledRequestStatusCode())
 		} else {
-			Expect(req).Should(BeNil(), "Received Unhandled Request")
+			formatted, err := httputil.DumpRequest(req, true)
+			Expect(err).NotTo(HaveOccurred(), "Encountered error while dumping HTTP request")
+			Expect(string(formatted)).Should(BeNil(), "Received Unhandled Request")
 		}
 	}
 }


### PR DESCRIPTION
Right now when the test server receives an unhandled HTTP request, it prints out default representation of the request object, which ends up being humongous (see https://gist.github.com/benmoss/86f69211817e33161aa678cb63e0ca57).

The httputil package offers a pretty printer for request objects that gives you the relevant details while sparing you the rest.

```
      Received Unhandled Request
      Expected
          <string>: POST /oauth/token HTTP/1.1
          Host: 127.0.0.1:51014
          Accept: application/json
          Accept-Encoding: gzip
          Content-Length: 97
          Content-Type: application/x-www-form-urlencoded
          User-Agent: Go-http-client/1.1

          client_id=test_client&client_secret=test_secret&grant_type=client_credentials&response_type=token
      to be nil
```

I can't see how we would encounter an error while dumping the request, but maybe someone more knowledgable than I might have an idea why this might be problematic.