### PR TITLE
Added first failure path matching for YAML

### DIFF
--- a/matchers/match_json_matcher.go
+++ b/matchers/match_json_matcher.go
@@ -28,7 +28,7 @@ func (matcher *MatchJSONMatcher) Match(actual interface{}) (success bool, err er
 	json.Unmarshal([]byte(actualString), &aval)
 	json.Unmarshal([]byte(expectedString), &eval)
 	var equal bool
-	equal, matcher.firstFailurePath = deepEqual(aval, eval)
+	equal, matcher.firstFailurePath = deepEqualJSON(aval, eval)
 	return equal, nil
 }
 
@@ -92,7 +92,7 @@ func (matcher *MatchJSONMatcher) prettyPrint(actual interface{}) (actualFormatte
 	return abuf.String(), ebuf.String(), nil
 }
 
-func deepEqual(a interface{}, b interface{}) (bool, []interface{}) {
+func deepEqualJSON(a interface{}, b interface{}) (bool, []interface{}) {
 	var errorPath []interface{}
 	if reflect.TypeOf(a) != reflect.TypeOf(b) {
 		return false, errorPath
@@ -105,7 +105,7 @@ func deepEqual(a interface{}, b interface{}) (bool, []interface{}) {
 		}
 
 		for i, v := range a.([]interface{}) {
-			elementEqual, keyPath := deepEqual(v, b.([]interface{})[i])
+			elementEqual, keyPath := deepEqualJSON(v, b.([]interface{})[i])
 			if !elementEqual {
 				return false, append(keyPath, i)
 			}
@@ -122,7 +122,7 @@ func deepEqual(a interface{}, b interface{}) (bool, []interface{}) {
 			if !ok {
 				return false, errorPath
 			}
-			elementEqual, keyPath := deepEqual(v1, v2)
+			elementEqual, keyPath := deepEqualJSON(v1, v2)
 			if !elementEqual {
 				return false, append(keyPath, k)
 			}

--- a/matchers/match_json_matcher.go
+++ b/matchers/match_json_matcher.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/onsi/gomega/format"
@@ -28,7 +27,7 @@ func (matcher *MatchJSONMatcher) Match(actual interface{}) (success bool, err er
 	json.Unmarshal([]byte(actualString), &aval)
 	json.Unmarshal([]byte(expectedString), &eval)
 	var equal bool
-	equal, matcher.firstFailurePath = deepEqualJSON(aval, eval)
+	equal, matcher.firstFailurePath = deepEqual(aval, eval)
 	return equal, nil
 }
 
@@ -90,46 +89,4 @@ func (matcher *MatchJSONMatcher) prettyPrint(actual interface{}) (actualFormatte
 	}
 
 	return abuf.String(), ebuf.String(), nil
-}
-
-func deepEqualJSON(a interface{}, b interface{}) (bool, []interface{}) {
-	var errorPath []interface{}
-	if reflect.TypeOf(a) != reflect.TypeOf(b) {
-		return false, errorPath
-	}
-
-	switch a.(type) {
-	case []interface{}:
-		if len(a.([]interface{})) != len(b.([]interface{})) {
-			return false, errorPath
-		}
-
-		for i, v := range a.([]interface{}) {
-			elementEqual, keyPath := deepEqualJSON(v, b.([]interface{})[i])
-			if !elementEqual {
-				return false, append(keyPath, i)
-			}
-		}
-		return true, errorPath
-
-	case map[string]interface{}:
-		if len(a.(map[string]interface{})) != len(b.(map[string]interface{})) {
-			return false, errorPath
-		}
-
-		for k, v1 := range a.(map[string]interface{}) {
-			v2, ok := b.(map[string]interface{})[k]
-			if !ok {
-				return false, errorPath
-			}
-			elementEqual, keyPath := deepEqualJSON(v1, v2)
-			if !elementEqual {
-				return false, append(keyPath, k)
-			}
-		}
-		return true, errorPath
-
-	default:
-		return a == b, errorPath
-	}
 }

--- a/matchers/match_yaml_matcher.go
+++ b/matchers/match_yaml_matcher.go
@@ -32,7 +32,7 @@ func (matcher *MatchYAMLMatcher) Match(actual interface{}) (success bool, err er
 	}
 
 	var equal bool
-	equal, matcher.firstFailurePath = deepEqualYAML(aval, eval)
+	equal, matcher.firstFailurePath = deepEqual(aval, eval)
 	return equal, nil
 }
 
@@ -77,7 +77,7 @@ func (matcher *MatchYAMLMatcher) toStrings(actual interface{}) (actualFormatted,
 	return actualString, expectedString, nil
 }
 
-func deepEqualYAML(a interface{}, b interface{}) (bool, []interface{}) {
+func deepEqual(a interface{}, b interface{}) (bool, []interface{}) {
 	var errorPath []interface{}
 	if reflect.TypeOf(a) != reflect.TypeOf(b) {
 		return false, errorPath
@@ -90,7 +90,7 @@ func deepEqualYAML(a interface{}, b interface{}) (bool, []interface{}) {
 		}
 
 		for i, v := range a.([]interface{}) {
-			elementEqual, keyPath := deepEqualYAML(v, b.([]interface{})[i])
+			elementEqual, keyPath := deepEqual(v, b.([]interface{})[i])
 			if !elementEqual {
 				return false, append(keyPath, i)
 			}
@@ -107,7 +107,24 @@ func deepEqualYAML(a interface{}, b interface{}) (bool, []interface{}) {
 			if !ok {
 				return false, errorPath
 			}
-			elementEqual, keyPath := deepEqualYAML(v1, v2)
+			elementEqual, keyPath := deepEqual(v1, v2)
+			if !elementEqual {
+				return false, append(keyPath, k)
+			}
+		}
+		return true, errorPath
+
+	case map[string]interface{}:
+		if len(a.(map[string]interface{})) != len(b.(map[string]interface{})) {
+			return false, errorPath
+		}
+
+		for k, v1 := range a.(map[string]interface{}) {
+			v2, ok := b.(map[string]interface{})[k]
+			if !ok {
+				return false, errorPath
+			}
+			elementEqual, keyPath := deepEqual(v1, v2)
 			if !elementEqual {
 				return false, append(keyPath, k)
 			}

--- a/matchers/match_yaml_matcher.go
+++ b/matchers/match_yaml_matcher.go
@@ -11,6 +11,8 @@ import (
 
 type MatchYAMLMatcher struct {
 	YAMLToMatch interface{}
+	firstFailurePath []interface{}
+
 }
 
 func (matcher *MatchYAMLMatcher) Match(actual interface{}) (success bool, err error) {
@@ -29,17 +31,19 @@ func (matcher *MatchYAMLMatcher) Match(actual interface{}) (success bool, err er
 		return false, fmt.Errorf("Expected '%s' should be valid YAML, but it is not.\nUnderlying error:%s", expectedString, err)
 	}
 
-	return reflect.DeepEqual(aval, eval), nil
+	var equal bool
+	equal, matcher.firstFailurePath = deepEqualYAML(aval, eval)
+	return equal, nil
 }
 
 func (matcher *MatchYAMLMatcher) FailureMessage(actual interface{}) (message string) {
 	actualString, expectedString, _ := matcher.toNormalisedStrings(actual)
-	return format.Message(actualString, "to match YAML of", expectedString)
+	return formattedMessage(format.Message(actualString, "to match YAML of", expectedString), matcher.firstFailurePath)
 }
 
 func (matcher *MatchYAMLMatcher) NegatedFailureMessage(actual interface{}) (message string) {
 	actualString, expectedString, _ := matcher.toNormalisedStrings(actual)
-	return format.Message(actualString, "not to match YAML of", expectedString)
+	return formattedMessage(format.Message(actualString, "not to match YAML of", expectedString), matcher.firstFailurePath)
 }
 
 func (matcher *MatchYAMLMatcher) toNormalisedStrings(actual interface{}) (actualFormatted, expectedFormatted string, err error) {
@@ -71,4 +75,46 @@ func (matcher *MatchYAMLMatcher) toStrings(actual interface{}) (actualFormatted,
 	}
 
 	return actualString, expectedString, nil
+}
+
+func deepEqualYAML(a interface{}, b interface{}) (bool, []interface{}) {
+	var errorPath []interface{}
+	if reflect.TypeOf(a) != reflect.TypeOf(b) {
+		return false, errorPath
+	}
+
+	switch a.(type) {
+	case []interface{}:
+		if len(a.([]interface{})) != len(b.([]interface{})) {
+			return false, errorPath
+		}
+
+		for i, v := range a.([]interface{}) {
+			elementEqual, keyPath := deepEqualYAML(v, b.([]interface{})[i])
+			if !elementEqual {
+				return false, append(keyPath, i)
+			}
+		}
+		return true, errorPath
+
+	case map[interface{}]interface{}:
+		if len(a.(map[interface{}]interface{})) != len(b.(map[interface{}]interface{})) {
+			return false, errorPath
+		}
+
+		for k, v1 := range a.(map[interface{}]interface{}) {
+			v2, ok := b.(map[interface{}]interface{})[k]
+			if !ok {
+				return false, errorPath
+			}
+			elementEqual, keyPath := deepEqualYAML(v1, v2)
+			if !elementEqual {
+				return false, append(keyPath, k)
+			}
+		}
+		return true, errorPath
+
+	default:
+		return a == b, errorPath
+	}
 }


### PR DESCRIPTION
@abg and I noticed that currently the JSON matcher lists the path to the first failure when a match fails. This PR implements the same feature with the YAML matcher.

We noticed that @Benjamintf1 also implements something similar [here](https://github.com/Benjamintf1/Expanded-Unmarshalled-Matchers/blob/master/expanded_yaml_matcher.go).