### PR TITLE
Fix data race in ghttp server

### DIFF
--- a/ghttp/test_server.go
+++ b/ghttp/test_server.go
@@ -124,7 +124,7 @@ func new() *Server {
 	return &Server{
 		AllowUnhandledRequests:     false,
 		UnhandledRequestStatusCode: http.StatusInternalServerError,
-		writeLock:                  &sync.Mutex{},
+		rwMutex:                    &sync.RWMutex{},
 	}
 }
 
@@ -179,8 +179,8 @@ type Server struct {
 	requestHandlers  []http.HandlerFunc
 	routedHandlers   []routedHandler
 
-	writeLock *sync.Mutex
-	calls     int
+	rwMutex *sync.RWMutex
+	calls   int
 }
 
 //Start() starts an unstarted ghttp server.  It is a catastrophic error to call Start more than once (thanks, httptest).
@@ -190,20 +190,24 @@ func (s *Server) Start() {
 
 //URL() returns a url that will hit the server
 func (s *Server) URL() string {
+	s.rwMutex.RLock()
+	defer s.rwMutex.RUnlock()
 	return s.HTTPTestServer.URL
 }
 
 //Addr() returns the address on which the server is listening.
 func (s *Server) Addr() string {
+	s.rwMutex.RLock()
+	defer s.rwMutex.RUnlock()
 	return s.HTTPTestServer.Listener.Addr().String()
 }
 
 //Close() should be called at the end of each test.  It spins down and cleans up the test server.
 func (s *Server) Close() {
-	s.writeLock.Lock()
+	s.rwMutex.Lock()
 	server := s.HTTPTestServer
 	s.HTTPTestServer = nil
-	s.writeLock.Unlock()
+	s.rwMutex.Unlock()
 
 	if server != nil {
 		server.Close()
@@ -219,7 +223,7 @@ func (s *Server) Close() {
 //   a) If AllowUnhandledRequests is set to true, the request will be handled with response code of UnhandledRequestStatusCode
 //   b) If AllowUnhandledRequests is false, the request will not be handled and the current test will be marked as failed.
 func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	s.writeLock.Lock()
+	s.rwMutex.Lock()
 	defer func() {
 		e := recover()
 		if e != nil {
@@ -252,15 +256,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	s.receivedRequests = append(s.receivedRequests, req)
 	if routedHandler, ok := s.handlerForRoute(req.Method, req.URL.Path); ok {
-		s.writeLock.Unlock()
+		s.rwMutex.Unlock()
 		routedHandler(w, req)
 	} else if s.calls < len(s.requestHandlers) {
 		h := s.requestHandlers[s.calls]
 		s.calls++
-		s.writeLock.Unlock()
+		s.rwMutex.Unlock()
 		h(w, req)
 	} else {
-		s.writeLock.Unlock()
+		s.rwMutex.Unlock()
 		if s.GetAllowUnhandledRequests() {
 			ioutil.ReadAll(req.Body)
 			req.Body.Close()
@@ -275,8 +279,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 //ReceivedRequests is an array containing all requests received by the server (both handled and unhandled requests)
 func (s *Server) ReceivedRequests() []*http.Request {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.RLock()
+	defer s.rwMutex.RUnlock()
 
 	return s.receivedRequests
 }
@@ -286,8 +290,8 @@ func (s *Server) ReceivedRequests() []*http.Request {
 //
 //The path may be either a string object or a *regexp.Regexp.
 func (s *Server) RouteToHandler(method string, path interface{}, handler http.HandlerFunc) {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.Lock()
+	defer s.rwMutex.Unlock()
 
 	rh := routedHandler{
 		method:  method,
@@ -332,8 +336,8 @@ func (s *Server) handlerForRoute(method string, path string) (http.HandlerFunc, 
 
 //AppendHandlers will appends http.HandlerFuncs to the server's list of registered handlers.  The first incoming request is handled by the first handler, the second by the second, etc...
 func (s *Server) AppendHandlers(handlers ...http.HandlerFunc) {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.Lock()
+	defer s.rwMutex.Unlock()
 
 	s.requestHandlers = append(s.requestHandlers, handlers...)
 }
@@ -342,23 +346,23 @@ func (s *Server) AppendHandlers(handlers ...http.HandlerFunc) {
 //This is useful, for example, when a server has been set up in a shared context, but must be tweaked
 //for a particular test.
 func (s *Server) SetHandler(index int, handler http.HandlerFunc) {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.Lock()
+	defer s.rwMutex.Unlock()
 
 	s.requestHandlers[index] = handler
 }
 
 //GetHandler returns the handler registered at the passed in index.
 func (s *Server) GetHandler(index int) http.HandlerFunc {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.RLock()
+	defer s.rwMutex.RUnlock()
 
 	return s.requestHandlers[index]
 }
 
 func (s *Server) Reset() {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.Lock()
+	defer s.rwMutex.Unlock()
 
 	s.HTTPTestServer.CloseClientConnections()
 	s.calls = 0
@@ -379,40 +383,40 @@ func (s *Server) WrapHandler(index int, handler http.HandlerFunc) {
 }
 
 func (s *Server) CloseClientConnections() {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.Lock()
+	defer s.rwMutex.Unlock()
 
 	s.HTTPTestServer.CloseClientConnections()
 }
 
 //SetAllowUnhandledRequests enables the server to accept unhandled requests.
 func (s *Server) SetAllowUnhandledRequests(allowUnhandledRequests bool) {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.Lock()
+	defer s.rwMutex.Unlock()
 
 	s.AllowUnhandledRequests = allowUnhandledRequests
 }
 
 //GetAllowUnhandledRequests returns true if the server accepts unhandled requests.
 func (s *Server) GetAllowUnhandledRequests() bool {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.RLock()
+	defer s.rwMutex.RUnlock()
 
 	return s.AllowUnhandledRequests
 }
 
 //SetUnhandledRequestStatusCode status code to be returned when the server receives unhandled requests
 func (s *Server) SetUnhandledRequestStatusCode(statusCode int) {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.Lock()
+	defer s.rwMutex.Unlock()
 
 	s.UnhandledRequestStatusCode = statusCode
 }
 
 //GetUnhandledRequestStatusCode returns the current status code being returned for unhandled requests
 func (s *Server) GetUnhandledRequestStatusCode() int {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.RLock()
+	defer s.rwMutex.RUnlock()
 
 	return s.UnhandledRequestStatusCode
 }


### PR DESCRIPTION
Accessing the HTTPTestServer variable can cause a data race.