### PR TITLE
Update documentation

### DIFF
--- a/gomega_dsl.go
+++ b/gomega_dsl.go
@@ -52,12 +52,12 @@ func RegisterFailHandler(handler types.GomegaFailHandler) {
 //
 //You'll need to call this at the top of each XUnit style test:
 //
-// func TestFarmHasCow(t *testing.T) {
-//     RegisterTestingT(t)
+//    func TestFarmHasCow(t *testing.T) {
+//        RegisterTestingT(t)
 //
-//	   f := farm.New([]string{"Cow", "Horse"})
-//     Expect(f.HasCow()).To(BeTrue(), "Farm should have cow")
-// }
+//        f := farm.New([]string{"Cow", "Horse"})
+//        Expect(f.HasCow()).To(BeTrue(), "Farm should have cow")
+//    }
 //
 // Note that this *testing.T is registered *globally* by Gomega (this is why you don't have to
 // pass `t` down to the matcher itself).  This means that you cannot run the XUnit style tests
@@ -91,7 +91,7 @@ func InterceptGomegaFailures(f func()) []string {
 }
 
 //Ω wraps an actual value allowing assertions to be made on it:
-//	Ω("foo").Should(Equal("foo"))
+//    Ω("foo").Should(Equal("foo"))
 //
 //If Ω is passed more than one argument it will pass the *first* argument to the matcher.
 //All subsequent arguments will be required to be nil/zero.
@@ -112,7 +112,7 @@ func Ω(actual interface{}, extra ...interface{}) GomegaAssertion {
 }
 
 //Expect wraps an actual value allowing assertions to be made on it:
-//	Expect("foo").To(Equal("foo"))
+//    Expect("foo").To(Equal("foo"))
 //
 //If Expect is passed more than one argument it will pass the *first* argument to the matcher.
 //All subsequent arguments will be required to be nil/zero.
@@ -125,7 +125,9 @@ func Ω(actual interface{}, extra ...interface{}) GomegaAssertion {
 //
 //Then:
 //    Expect(MyAmazingThing()).Should(Equal(3))
-//Will succeed only if `MyAmazingThing()` returns `(3, nil)`
+//Will succeed only if:
+//    MyAmazingThing()
+//    // Output: (3, nil)
 //
 //Expect and Ω are identical
 func Expect(actual interface{}, extra ...interface{}) GomegaAssertion {
@@ -326,12 +328,12 @@ type GomegaWithT struct {
 //NewGomegaWithT takes a *testing.T and returngs a `GomegaWithT` allowing you to use `Expect`, `Eventually`, and `Consistently` along with
 //Gomega's rich ecosystem of matchers in standard `testing` test suits.
 //
-// func TestFarmHasCow(t *testing.T) {
-//     g := GomegaWithT(t)
+//    func TestFarmHasCow(t *testing.T) {
+//        g := GomegaWithT(t)
 //
-//	   f := farm.New([]string{"Cow", "Horse"})
-//     g.Expect(f.HasCow()).To(BeTrue(), "Farm should have cow")
-// }
+//        f := farm.New([]string{"Cow", "Horse"})
+//        g.Expect(f.HasCow()).To(BeTrue(), "Farm should have cow")
+//     }
 func NewGomegaWithT(t types.GomegaTestingT) *GomegaWithT {
 	return &GomegaWithT{
 		t: t,

--- a/gomega_dsl.go
+++ b/gomega_dsl.go
@@ -125,9 +125,7 @@ func Ω(actual interface{}, extra ...interface{}) GomegaAssertion {
 //
 //Then:
 //    Expect(MyAmazingThing()).Should(Equal(3))
-//Will succeed only if:
-//    MyAmazingThing()
-//    // Output: (3, nil)
+//Will succeed only if `MyAmazingThing()` returns `(3, nil)`
 //
 //Expect and Ω are identical
 func Expect(actual interface{}, extra ...interface{}) GomegaAssertion {

--- a/gstruct/elements.go
+++ b/gstruct/elements.go
@@ -13,10 +13,14 @@ import (
 
 //MatchAllElements succeeds if every element of a slice matches the element matcher it maps to
 //through the id function, and every element matcher is matched.
-//  Expect([]string{"a", "b"}).To(MatchAllElements(idFn, matchers.Elements{
-//      "a": BeEqual("a"),
-//      "b": BeEqual("b"),
-//  })
+//    idFn := func(element interface{}) string {
+//        return fmt.Sprintf("%v", element)
+//    }
+//
+//    Expect([]string{"a", "b"}).To(MatchAllElements(idFn, Elements{
+//        "a": Equal("a"),
+//        "b": Equal("b"),
+//    }))
 func MatchAllElements(identifier Identifier, elements Elements) types.GomegaMatcher {
 	return &ElementsMatcher{
 		Identifier: identifier,
@@ -26,10 +30,20 @@ func MatchAllElements(identifier Identifier, elements Elements) types.GomegaMatc
 
 //MatchElements succeeds if each element of a slice matches the element matcher it maps to
 //through the id function. It can ignore extra elements and/or missing elements.
-//  Expect([]string{"a", "c"}).To(MatchElements(idFn, IgnoreMissing|IgnoreExtra, matchers.Elements{
-//      "a": BeEqual("a")
-//      "b": BeEqual("b"),
-//  })
+//    idFn := func(element interface{}) string {
+//        return fmt.Sprintf("%v", element)
+//    }
+//
+//    Expect([]string{"a", "b", "c"}).To(MatchElements(idFn, IgnoreExtras, Elements{
+//        "a": Equal("a"),
+//        "b": Equal("b"),
+//    }))
+//    Expect([]string{"a", "c"}).To(MatchElements(idFn, IgnoreMissing, Elements{
+//        "a": Equal("a"),
+//        "b": Equal("b"),
+//        "c": Equal("c"),
+//        "d": Equal("d"),
+//    }))
 func MatchElements(identifier Identifier, options Options, elements Elements) types.GomegaMatcher {
 	return &ElementsMatcher{
 		Identifier:      identifier,

--- a/gstruct/fields.go
+++ b/gstruct/fields.go
@@ -14,10 +14,21 @@ import (
 
 //MatchAllFields succeeds if every field of a struct matches the field matcher associated with
 //it, and every element matcher is matched.
-//  Expect([]string{"a", "b"}).To(MatchAllFields(gstruct.Fields{
-//      "a": BeEqual("a"),
-//      "b": BeEqual("b"),
-//  })
+//    actual := struct{
+//      A int
+//      B []bool
+//      C string
+//    }{
+//      A: 5,
+//      B: []bool{true, false},
+//      C: "foo",
+//    }
+//
+//    Expect(actual).To(MatchAllFields(Fields{
+//      "A": Equal(5),
+//      "B": ConsistOf(true, false),
+//      "C": Equal("foo"),
+//    }))
 func MatchAllFields(fields Fields) types.GomegaMatcher {
 	return &FieldsMatcher{
 		Fields: fields,
@@ -26,10 +37,26 @@ func MatchAllFields(fields Fields) types.GomegaMatcher {
 
 //MatchFields succeeds if each element of a struct matches the field matcher associated with
 //it. It can ignore extra fields and/or missing fields.
-//  Expect([]string{"a", "c"}).To(MatchFields(IgnoreMissing|IgnoreExtra, gstruct.Fields{
-//      "a": BeEqual("a")
-//      "b": BeEqual("b"),
-//  })
+//    actual := struct{
+//      A int
+//      B []bool
+//      C string
+//    }{
+//      A: 5,
+//      B: []bool{true, false},
+//      C: "foo",
+//    }
+//
+//    Expect(actual).To(MatchFields(IgnoreExtras, Fields{
+//      "A": Equal(5),
+//      "B": ConsistOf(true, false),
+//    }))
+//    Expect(actual).To(MatchFields(IgnoreMissing, Fields{
+//      "A": Equal(5),
+//      "B": ConsistOf(true, false),
+//      "C": Equal("foo"),
+//      "D": Equal("extra"),
+//    }))
 func MatchFields(options Options, fields Fields) types.GomegaMatcher {
 	return &FieldsMatcher{
 		Fields:        fields,

--- a/matchers.go
+++ b/matchers.go
@@ -344,9 +344,9 @@ func BeTemporally(comparator string, compareTo time.Time, threshold ...time.Dura
 
 //BeAssignableToTypeOf succeeds if actual is assignable to the type of expected.
 //It will return an error when one of the values is nil.
-//	  Expect(0).Should(BeAssignableToTypeOf(0))         // Same values
-//	  Expect(5).Should(BeAssignableToTypeOf(-1))        // different values same type
-//	  Expect("foo").Should(BeAssignableToTypeOf("bar")) // different values same type
+//    Expect(0).Should(BeAssignableToTypeOf(0))         // Same values
+//    Expect(5).Should(BeAssignableToTypeOf(-1))        // different values same type
+//    Expect("foo").Should(BeAssignableToTypeOf("bar")) // different values same type
 //    Expect(struct{ Foo string }{}).Should(BeAssignableToTypeOf(struct{ Foo string }{}))
 func BeAssignableToTypeOf(expected interface{}) types.GomegaMatcher {
 	return &matchers.AssignableToTypeOfMatcher{


### PR DESCRIPTION
* whitespace consistency
* updated examples where needed

Updated documentation per https://github.com/onsi/gomega/issues/288

No broken tests

```
[1528843848] Format Suite - 41 specs - 7 nodes ••••••••••••••••••••••••••••••••••••••••• SUCCESS! 41.022564ms
[1528843848] Gbytes Suite - 36 specs - 7 nodes •••••••••••••••••••••••••••••••••••• SUCCESS! 135.294936ms
[1528843848] Gexec Suite - 35 specs - 7 nodes ••••••••••••••••••••••••••••••••••• SUCCESS! 4.557117779s
[1528843848] GHTTP Suite - 72 specs - 7 nodes •••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••• SUCCESS! 74.799789ms
[1528843848] Gstruct Suite - 19 specs - 7 nodes ••••••••••••••••••• SUCCESS! 23.359218ms
[1528843848] Assertion Suite - 18 specs - 7 nodes •••••••••••••••••• SUCCESS! 36.525491ms
[1528843848] AsyncAssertion Suite - 21 specs - 7 nodes ••••••••••••••••••••• SUCCESS! 440.970718ms
=== RUN   TestTestingT
--- PASS: TestTestingT (0.00s)
=== RUN   TestGomegaWithT
--- PASS: TestGomegaWithT (0.00s)
PASS
[1528843848] Gomega Matchers - 220 specs - 7 nodes •••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••• SUCCESS! 190.416708ms
Ginkgo ran 9 suites in 9.737072008s
Test Suite Passed
```

No warnings or output for `go vet`