### PR TITLE
Fix MatchJSON fail to parse json.RawMessage

### DIFF
--- a/matchers/match_json_matcher_test.go
+++ b/matchers/match_json_matcher_test.go
@@ -1,6 +1,8 @@
 package matchers_test
 
 import (
+	"encoding/json"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/matchers"
@@ -28,6 +30,10 @@ var _ = Describe("MatchJSONMatcher", func() {
 			Expect([]byte("{}")).Should(MatchJSON([]byte("{}")))
 			Expect("{}").Should(MatchJSON([]byte("{}")))
 			Expect([]byte("{}")).Should(MatchJSON("{}"))
+		})
+
+		It("should work with json.RawMessage", func() {
+			Expect([]byte(`{"a": 1}`)).Should(MatchJSON(json.RawMessage(`{"a": 1}`)))
 		})
 	})
 

--- a/matchers/type_support.go
+++ b/matchers/type_support.go
@@ -9,6 +9,7 @@ http://onsi.github.io/gomega/
 package matchers
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 )
@@ -131,6 +132,11 @@ func toString(a interface{}) (string, bool) {
 	aStringer, isStringer := a.(fmt.Stringer)
 	if isStringer {
 		return aStringer.String(), true
+	}
+
+	aJSONRawMessage, isJSONRawMessage := a.(json.RawMessage)
+	if isJSONRawMessage {
+		return string(aJSONRawMessage), true
 	}
 
 	return "", false


### PR DESCRIPTION
I add a type assertion for `json.RawMessage` because it's actually an alias of `[]byte`

fix #290