### PR TITLE
Work around go vet issue with Go v1.11

### DIFF
--- a/gbytes/say_matcher.go
+++ b/gbytes/say_matcher.go
@@ -36,12 +36,11 @@ In such cases, Say simply operates on the *gbytes.Buffer returned by Buffer()
 If the buffer is closed, the Say matcher will tell Eventually to abort.
 */
 func Say(expected string, args ...interface{}) *sayMatcher {
-	formattedRegexp := expected
 	if len(args) > 0 {
-		formattedRegexp = fmt.Sprintf(expected, args...)
+		expected = fmt.Sprintf(expected, args...)
 	}
 	return &sayMatcher{
-		re: regexp.MustCompile(formattedRegexp),
+		re: regexp.MustCompile(expected),
 	}
 }
 

--- a/gbytes/say_matcher_test.go
+++ b/gbytes/say_matcher_test.go
@@ -43,6 +43,11 @@ var _ = Describe("SayMatcher", func() {
 			Expect(buffer).Should(Say("a%sc", "b"))
 		})
 
+		It("should match literal %", func() {
+			buffer.Write([]byte("%"))
+			Expect(buffer).Should(Say("abc%"))
+		})
+
 		It("should use a regular expression", func() {
 			Expect(buffer).Should(Say("a.c"))
 		})


### PR DESCRIPTION
- go vet in Go v1.11 identifies `Say()` as a print wrapper
  - go vet will then fail for `Say("%")` because this is not a valid
  Sprintf template
- Because of https://github.com/golang/go/issues/26486, changing the way
  that the functon is written will work around the vet issue
- I have added a comment documenting that this is not ideal in
  https://github.com/golang/go/issues/26555#issuecomment-419168158