### PR TITLE
fix error output

### DIFF
--- a/gomega_dsl.go
+++ b/gomega_dsl.go
@@ -46,9 +46,22 @@ func RegisterFailHandler(handler types.GomegaFailHandler) {
 		globalFailWrapper = nil
 		return
 	}
+
 	globalFailWrapper = &types.GomegaFailWrapper{
 		Fail:        handler,
 		TWithHelper: testingtsupport.EmptyTWithHelper{},
+	}
+}
+
+func RegisterFailHandlerWithT(t types.TWithHelper, handler types.GomegaFailHandler) {
+	if handler == nil {
+		globalFailWrapper = nil
+		return
+	}
+
+	globalFailWrapper = &types.GomegaFailWrapper{
+		Fail:        handler,
+		TWithHelper: t,
 	}
 }
 
@@ -74,7 +87,12 @@ func RegisterFailHandler(handler types.GomegaFailHandler) {
 //
 // (As an aside: Ginkgo gets around this limitation by running parallel tests in different *processes*).
 func RegisterTestingT(t types.GomegaTestingT) {
-	RegisterFailHandler(testingtsupport.BuildTestingTGomegaFailWrapper(t).Fail)
+	tWithHelper, hasHelper := t.(types.TWithHelper)
+	if !hasHelper {
+		RegisterFailHandler(testingtsupport.BuildTestingTGomegaFailWrapper(t).Fail)
+		return
+	}
+	RegisterFailHandlerWithT(tWithHelper, testingtsupport.BuildTestingTGomegaFailWrapper(t).Fail)
 }
 
 //InterceptGomegaHandlers runs a given callback and returns an array of


### PR DESCRIPTION
In #297, error output was made much more concise! 🎉 Unfortunately, it was too concise, as #302 reported. This is because some parts of gomega were using an EmptyTWithHandler, unnecessarily. This PR ensures that the testing.T that you pass when you RegisterTestingT is used throughout.

This also obviates the need for #309.

- Fixes #302 
- Fixes #309 