### PR TITLE
Clarify message for unexpected errors

### DIFF
--- a/matchers/have_occurred_matcher.go
+++ b/matchers/have_occurred_matcher.go
@@ -29,5 +29,5 @@ func (matcher *HaveOccurredMatcher) FailureMessage(actual interface{}) (message 
 }
 
 func (matcher *HaveOccurredMatcher) NegatedFailureMessage(actual interface{}) (message string) {
-	return fmt.Sprintf("Expected error:\n%s\n%s\n%s", format.Object(actual, 1), format.IndentString(actual.(error).Error(), 1), "not to have occurred")
+	return fmt.Sprintf("Unexpected error:\n%s\n%s\n%s", format.Object(actual, 1), format.IndentString(actual.(error).Error(), 1), "occurred")
 }


### PR DESCRIPTION
When reading a lot, the phrasing "Expected error" at the start makes me think it
*is* expected...then we say "not to have occurred" which is awkward.

Let's avoid the double negative.