### PR TITLE
mark all uncovered files so go-testcov ./... works

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -1,6 +1,9 @@
 /*
 Gomega's format package pretty-prints objects.  It explores input objects recursively and generates formatted, indented output with type information.
 */
+
+// untested sections: 4
+
 package format
 
 import (

--- a/gbytes/say_matcher.go
+++ b/gbytes/say_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 1
+
 package gbytes
 
 import (

--- a/gexec/build.go
+++ b/gexec/build.go
@@ -1,3 +1,5 @@
+// untested sections: 5
+
 package gexec
 
 import (

--- a/gexec/exit_matcher.go
+++ b/gexec/exit_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 2
+
 package gexec
 
 import (

--- a/gexec/prefixed_writer.go
+++ b/gexec/prefixed_writer.go
@@ -1,3 +1,5 @@
+// untested sections: 1
+
 package gexec
 
 import (

--- a/gexec/session.go
+++ b/gexec/session.go
@@ -1,6 +1,9 @@
 /*
 Package gexec provides support for testing external processes.
 */
+
+// untested sections: 1
+
 package gexec
 
 import (

--- a/ghttp/handlers.go
+++ b/ghttp/handlers.go
@@ -1,3 +1,5 @@
+// untested sections: 3
+
 package ghttp
 
 import (

--- a/ghttp/test_server.go
+++ b/ghttp/test_server.go
@@ -103,6 +103,9 @@ A more comprehensive example is available at https://onsi.github.io/gomega/#_tes
 		})
 	})
 */
+
+// untested sections: 5
+
 package ghttp
 
 import (

--- a/gstruct/elements.go
+++ b/gstruct/elements.go
@@ -1,3 +1,5 @@
+// untested sections: 6
+
 package gstruct
 
 import (

--- a/gstruct/fields.go
+++ b/gstruct/fields.go
@@ -1,3 +1,5 @@
+// untested sections: 10
+
 package gstruct
 
 import (

--- a/gstruct/ignore.go
+++ b/gstruct/ignore.go
@@ -1,3 +1,5 @@
+// untested sections: 2
+
 package gstruct
 
 import (

--- a/gstruct/keys.go
+++ b/gstruct/keys.go
@@ -1,3 +1,5 @@
+// untested sections: 9
+
 package gstruct
 
 import (

--- a/gstruct/pointer.go
+++ b/gstruct/pointer.go
@@ -1,3 +1,5 @@
+// untested sections: 3
+
 package gstruct
 
 import (

--- a/internal/asyncassertion/async_assertion.go
+++ b/internal/asyncassertion/async_assertion.go
@@ -1,3 +1,5 @@
+// untested sections: 2
+
 package asyncassertion
 
 import (

--- a/matchers/assignable_to_type_of_matcher.go
+++ b/matchers/assignable_to_type_of_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 2
+
 package matchers
 
 import (

--- a/matchers/be_a_directory.go
+++ b/matchers/be_a_directory.go
@@ -1,3 +1,5 @@
+// untested sections: 5
+
 package matchers
 
 import (

--- a/matchers/be_a_regular_file.go
+++ b/matchers/be_a_regular_file.go
@@ -1,3 +1,5 @@
+// untested sections: 5
+
 package matchers
 
 import (

--- a/matchers/be_an_existing_file.go
+++ b/matchers/be_an_existing_file.go
@@ -1,3 +1,5 @@
+// untested sections: 3
+
 package matchers
 
 import (

--- a/matchers/be_closed_matcher.go
+++ b/matchers/be_closed_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 2
+
 package matchers
 
 import (

--- a/matchers/be_empty_matcher.go
+++ b/matchers/be_empty_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 2
+
 package matchers
 
 import (

--- a/matchers/be_equivalent_to_matcher.go
+++ b/matchers/be_equivalent_to_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 2
+
 package matchers
 
 import (

--- a/matchers/be_false_matcher.go
+++ b/matchers/be_false_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 2
+
 package matchers
 
 import (

--- a/matchers/be_identical_to.go
+++ b/matchers/be_identical_to.go
@@ -1,3 +1,5 @@
+// untested sections: 2
+
 package matchers
 
 import (

--- a/matchers/be_nil_matcher.go
+++ b/matchers/be_nil_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 2
+
 package matchers
 
 import "github.com/onsi/gomega/format"

--- a/matchers/be_numerically_matcher.go
+++ b/matchers/be_numerically_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 4
+
 package matchers
 
 import (

--- a/matchers/be_sent_matcher.go
+++ b/matchers/be_sent_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 3
+
 package matchers
 
 import (

--- a/matchers/be_temporally_matcher.go
+++ b/matchers/be_temporally_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 3
+
 package matchers
 
 import (

--- a/matchers/be_true_matcher.go
+++ b/matchers/be_true_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 2
+
 package matchers
 
 import (

--- a/matchers/consist_of.go
+++ b/matchers/consist_of.go
@@ -1,3 +1,5 @@
+// untested sections: 3
+
 package matchers
 
 import (

--- a/matchers/contain_element_matcher.go
+++ b/matchers/contain_element_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 2
+
 package matchers
 
 import (

--- a/matchers/contain_substring_matcher.go
+++ b/matchers/contain_substring_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 2
+
 package matchers
 
 import (

--- a/matchers/have_cap_matcher.go
+++ b/matchers/have_cap_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 2
+
 package matchers
 
 import (

--- a/matchers/have_key_matcher.go
+++ b/matchers/have_key_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 6
+
 package matchers
 
 import (

--- a/matchers/have_key_with_value_matcher.go
+++ b/matchers/have_key_with_value_matcher.go
@@ -1,3 +1,5 @@
+// untested sections:10
+
 package matchers
 
 import (

--- a/matchers/have_occurred_matcher.go
+++ b/matchers/have_occurred_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 2
+
 package matchers
 
 import (

--- a/matchers/receive_matcher.go
+++ b/matchers/receive_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 3
+
 package matchers
 
 import (

--- a/matchers/semi_structured_data_support.go
+++ b/matchers/semi_structured_data_support.go
@@ -1,3 +1,5 @@
+// untested sections: 5
+
 package matchers
 
 import (

--- a/matchers/type_support.go
+++ b/matchers/type_support.go
@@ -6,6 +6,9 @@ See the docs for Gomega for documentation on the matchers
 
 http://onsi.github.io/gomega/
 */
+
+// untested sections: 11
+
 package matchers
 
 import (


### PR DESCRIPTION
WIP followup to https://github.com/onsi/gomega/pull/316

afaik options are:
 - replace Makefile `ginko` with `go-testcov ./...` (ugly formatting and all options gone)
 - add `go-testcov ./...` as an extra run (slows things down)
 - add `go-testcov ./...` as `make coverage`

atm a full run fails on ~25 files having coverage gaps, so added these `uncovered` declarations to make it pass (and fail if anything new uncovered is added)

@williammartin let me know how you like this or if you have ideas how to improve