### PR TITLE
display special chars on error

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -97,7 +97,16 @@ func MessageWithDiff(actual, message, expected string) string {
 		padding := strings.Repeat(" ", spaceFromMessageToActual+spacesBeforeFormattedMismatch) + "|"
 		return Message(formattedActual, message+padding, formattedExpected)
 	}
+
+	actual = escapedWithGoSyntax(actual)
+	expected = escapedWithGoSyntax(expected)
+
 	return Message(actual, message, expected)
+}
+
+func escapedWithGoSyntax(str string) string {
+	withQuotes := fmt.Sprintf("%q", str)
+	return withQuotes[1 : len(withQuotes)-1]
 }
 
 func truncateAndFormat(str string, index int) string {

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -167,6 +167,13 @@ var _ = Describe("Format", func() {
 			Expect(MessageWithDiff(stringA, "to equal", stringB)).Should(Equal(expectedTruncatedMultiByteFailureMessage))
 		})
 
+		It("prints special characters", func() {
+			stringA := "\n"
+			stringB := "something_else"
+
+			Expect(MessageWithDiff(stringA, "to equal", stringB)).Should(Equal(expectedSpecialCharacterFailureMessage))
+		})
+
 		Context("With truncated diff disabled", func() {
 			BeforeEach(func() {
 				TruncatedDiff = false
@@ -624,4 +631,12 @@ Expected
     <string>: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 to equal
     <string>: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaazaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`)
+
+var expectedSpecialCharacterFailureMessage = strings.TrimSpace(`
+Expected
+    <string>: \n
+to equal
+    <string>: something_else
+
 `)


### PR DESCRIPTION
previously, special chars would be rendered via the terminal
making it difficult to see errors

use %q to safely display special chars on the terminal
this addresses issue #328

Signed-off-by: Paul Nikonowicz <pnikonowicz@pivotal.io>