### PR TITLE
Xf/fix keys errors

### DIFF
--- a/gstruct/fields.go
+++ b/gstruct/fields.go
@@ -118,12 +118,7 @@ func (m *FieldsMatcher) matchFields(actual interface{}) (errs []error) {
 				return nil
 			}
 
-			var field interface{}
-			if val.Field(i).IsValid() {
-				field = val.Field(i).Interface()
-			} else {
-				field = reflect.Zero(typ.Field(i).Type)
-			}
+			field := val.Field(i).Interface()
 
 			match, err := matcher.Match(field)
 			if err != nil {

--- a/gstruct/fields_test.go
+++ b/gstruct/fields_test.go
@@ -73,4 +73,29 @@ var _ = Describe("Struct", func() {
 		})
 		Expect(allFields).ShouldNot(m, "should run nested matchers")
 	})
+
+	It("should produce sensible error messages", func() {
+		m := MatchAllFields(Fields{
+			"B": Equal("b"),
+			"A": Equal("a"),
+		})
+
+		actual := struct{ A, C string }{A: "b", C: "c"}
+
+		//Because the order of the constituent errors can't be guaranteed,
+		//we do a number of checks to make sure everything's included
+		m.Match(actual)
+		Expect(m.FailureMessage(actual)).Should(HavePrefix(
+			"Expected\n    <string>: \nto match fields: {\n",
+		))
+		Expect(m.FailureMessage(actual)).Should(ContainSubstring(
+			".A:\n	Expected\n	    <string>: b\n	to equal\n	    <string>: a\n",
+		))
+		Expect(m.FailureMessage(actual)).Should(ContainSubstring(
+			"missing expected field B\n",
+		))
+		Expect(m.FailureMessage(actual)).Should(ContainSubstring(
+			".C:\n	unexpected field C: {A:b C:c}",
+		))
+	})
 })

--- a/gstruct/keys.go
+++ b/gstruct/keys.go
@@ -77,9 +77,9 @@ func (m *KeysMatcher) matchKeys(actual interface{}) (errs []error) {
 				return nil
 			}
 
-			valValue := actualValue.MapIndex(keyValue)
+			valInterface := actualValue.MapIndex(keyValue).Interface()
 
-			match, err := matcher.Match(valValue.Interface())
+			match, err := matcher.Match(valInterface)
 			if err != nil {
 				return err
 			}
@@ -88,7 +88,7 @@ func (m *KeysMatcher) matchKeys(actual interface{}) (errs []error) {
 				if nesting, ok := matcher.(errorsutil.NestingMatcher); ok {
 					return errorsutil.AggregateError(nesting.Failures())
 				}
-				return errors.New(matcher.FailureMessage(valValue))
+				return errors.New(matcher.FailureMessage(valInterface))
 			}
 			return nil
 		}()

--- a/gstruct/keys_test.go
+++ b/gstruct/keys_test.go
@@ -73,4 +73,29 @@ var _ = Describe("Map", func() {
 		})
 		Expect(allKeys).ShouldNot(m, "should run nested matchers")
 	})
+
+	It("should produce sensible error messages", func() {
+		m := MatchAllKeys(Keys{
+			"B": Equal("b"),
+			"A": Equal("a"),
+		})
+
+		actual := map[string]string{"A": "b", "C": "c"}
+
+		//Because the order of the constituent errors can't be guaranteed,
+		//we do a number of checks to make sure everything's included
+		m.Match(actual)
+		Expect(m.FailureMessage(actual)).Should(HavePrefix(
+			"Expected\n    <string>: \nto match keys: {\n",
+		))
+		Expect(m.FailureMessage(actual)).Should(ContainSubstring(
+			".\"A\":\n	Expected\n	    <string>: b\n	to equal\n	    <string>: a\n",
+		))
+		Expect(m.FailureMessage(actual)).Should(ContainSubstring(
+			"missing expected key B\n",
+		))
+		Expect(m.FailureMessage(actual)).Should(ContainSubstring(
+			".\"C\":\n	unexpected key C: map[",
+		))
+	})
 })


### PR DESCRIPTION
Small fix to my previous `MatchKeys` PR. That code had been forming the new failure messages using the `reflect.Value` version of the the `actual`, rather than the underlying interface, leading to obnoxious and uninformative error messages.

1. Fixed error messages in `keys.go`.
2. In the process I noticed that `reflect.Value.MapIndex` and `reflect.Value.Field` both guarantee to never return an invalid `reflect.Value`, so I removed what I believe to be a redundant check in `fields.go`. I'm happy to put it back if you disagree or prefer to include it for style reasons.