### PR TITLE
Reenable gotip in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
   - 1.10.x
   - 1.11.x
   - 1.12.x
+  - gotip
 
 env:
   - GO111MODULE=on


### PR DESCRIPTION
Once `reflect.DeepEqual` is fixed in `gotip` we should merge this. Currently blocked.