### PR TITLE
export format property variables

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -38,11 +38,11 @@ var TruncatedDiff = true
 
 // TruncateThreshold (default 50) specifies the maximum length string to print in string comparison assertion error
 // messages.
-var TruncateThreshold = 50
+var TruncateThreshold uint = 50
 
 // CharactersAroundMismatchToInclude (default 5) specifies how many contextual characters should be printed before and
 // after the first diff location in a truncated string assertion error message.
-var CharactersAroundMismatchToInclude = 5
+var CharactersAroundMismatchToInclude uint = 5
 
 // Ctx interface defined here to keep backwards compatibility with go < 1.7
 // It matches the context.Context interface
@@ -96,7 +96,7 @@ to equal               |
 */
 
 func MessageWithDiff(actual, message, expected string) string {
-	if TruncatedDiff && len(actual) >= TruncateThreshold && len(expected) >= TruncateThreshold {
+	if TruncatedDiff && len(actual) >= int(TruncateThreshold) && len(expected) >= int(TruncateThreshold) {
 		diffPoint := findFirstMismatch(actual, expected)
 		formattedActual := truncateAndFormat(actual, diffPoint)
 		formattedExpected := truncateAndFormat(expected, diffPoint)
@@ -124,7 +124,7 @@ func truncateAndFormat(str string, index int) string {
 	leftPadding := `...`
 	rightPadding := `...`
 
-	start := index - CharactersAroundMismatchToInclude
+	start := index - int(CharactersAroundMismatchToInclude)
 	if start < 0 {
 		start = 0
 		leftPadding = ""
@@ -132,7 +132,7 @@ func truncateAndFormat(str string, index int) string {
 
 	// slice index must include the mis-matched character
 	lengthOfMismatchedCharacter := 1
-	end := index + CharactersAroundMismatchToInclude + lengthOfMismatchedCharacter
+	end := index + int(CharactersAroundMismatchToInclude) + lengthOfMismatchedCharacter
 	if end > len(str) {
 		end = len(str)
 		rightPadding = ""

--- a/format/format.go
+++ b/format/format.go
@@ -33,6 +33,14 @@ var PrintContextObjects = false
 // TruncatedDiff choose if we should display a truncated pretty diff or not
 var TruncatedDiff = true
 
+// TruncateThreshold (default 50) specifies the maximum length string to print in string comparison assertion error
+// messages.
+var TruncateThreshold = 50
+
+// CharactersAroundMismatchToInclude (default 5) specifies how many contextual characters should be printed before and
+// after the first diff location in a truncated string assertion error message.
+var CharactersAroundMismatchToInclude = 5
+
 // Ctx interface defined here to keep backwards compatability with go < 1.7
 // It matches the context.Context interface
 type Ctx interface {
@@ -85,7 +93,7 @@ to equal               |
 */
 
 func MessageWithDiff(actual, message, expected string) string {
-	if TruncatedDiff && len(actual) >= truncateThreshold && len(expected) >= truncateThreshold {
+	if TruncatedDiff && len(actual) >= TruncateThreshold && len(expected) >= TruncateThreshold {
 		diffPoint := findFirstMismatch(actual, expected)
 		formattedActual := truncateAndFormat(actual, diffPoint)
 		formattedExpected := truncateAndFormat(expected, diffPoint)
@@ -104,7 +112,7 @@ func truncateAndFormat(str string, index int) string {
 	leftPadding := `...`
 	rightPadding := `...`
 
-	start := index - charactersAroundMismatchToInclude
+	start := index - CharactersAroundMismatchToInclude
 	if start < 0 {
 		start = 0
 		leftPadding = ""
@@ -112,7 +120,7 @@ func truncateAndFormat(str string, index int) string {
 
 	// slice index must include the mis-matched character
 	lengthOfMismatchedCharacter := 1
-	end := index + charactersAroundMismatchToInclude + lengthOfMismatchedCharacter
+	end := index + CharactersAroundMismatchToInclude + lengthOfMismatchedCharacter
 	if end > len(str) {
 		end = len(str)
 		rightPadding = ""
@@ -140,11 +148,6 @@ func findFirstMismatch(a, b string) int {
 
 	return 0
 }
-
-const (
-	truncateThreshold                 = 50
-	charactersAroundMismatchToInclude = 5
-)
 
 /*
 Pretty prints the passed in object at the passed in indentation level.

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -192,7 +192,7 @@ var _ = Describe("Format", func() {
 		})
 
 		Context("With alternate diff lengths", func() {
-			initialValue := TruncateThreshold // 5 by default
+			initialValue := TruncateThreshold // 50 by default
 			BeforeEach(func() {
 				TruncateThreshold = 10000
 			})
@@ -200,6 +200,7 @@ var _ = Describe("Format", func() {
 			AfterEach(func() {
 				TruncateThreshold = initialValue
 			})
+
 			It("should show the full diff when truncate threshold is increased beyond length of strings", func() {
 				stringWithB := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 				stringWithZ := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaazaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -217,12 +218,69 @@ var _ = Describe("Format", func() {
 			AfterEach(func() {
 				CharactersAroundMismatchToInclude = initialValue
 			})
+
 			It("it shows more characters around a line length mismatch", func() {
 				smallString := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 				largeString := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 				Expect(MessageWithDiff(largeString, "to equal", smallString)).Should(Equal(expectedTruncatedStartSizeFailureMessageExtraDiff))
 				Expect(MessageWithDiff(smallString, "to equal", largeString)).Should(Equal(expectedTruncatedStartSizeSwappedFailureMessageExtraDiff))
+			})
+		})
+
+		Describe("At extremes of configurable values", func() {
+			Context("with zero-length threshold", func() {
+				initialValue := TruncateThreshold // 50 by default
+				BeforeEach(func() {
+					TruncateThreshold = 0
+				})
+
+				AfterEach(func() {
+					TruncateThreshold = initialValue
+				})
+
+				It("should show the full diff when truncate threshold is increased beyond length of strings", func() {
+					stringWithB := "aba"
+					stringWithZ := "aza"
+					Expect(MessageWithDiff(stringWithB, "to equal", stringWithZ)).Should(Equal(expectedDiffSmallThreshold))
+				})
+			})
+
+			Context("with zero characters around mismatch", func() {
+				initialValue := CharactersAroundMismatchToInclude // 5 by default
+				BeforeEach(func() {
+					CharactersAroundMismatchToInclude = 0
+				})
+
+				AfterEach(func() {
+					CharactersAroundMismatchToInclude = initialValue
+				})
+
+				It("", func() {
+					stringWithB := "aba"
+					stringWithZ := "aza"
+					Expect(MessageWithDiff(stringWithB, "to equal", stringWithZ)).Should(Equal(expectedDiffZeroMismatch))
+				})
+			})
+
+			Context("with zero-length threshold and zero characters around mismatch", func() {
+				initialCharactersAroundMismatch := CharactersAroundMismatchToInclude
+				initialTruncateThreshold := TruncateThreshold
+				BeforeEach(func() {
+					CharactersAroundMismatchToInclude = 0
+					TruncateThreshold = 0
+				})
+
+				AfterEach(func() {
+					CharactersAroundMismatchToInclude = initialCharactersAroundMismatch
+					TruncateThreshold = initialTruncateThreshold
+				})
+
+				It("", func() {
+					stringWithB := "aba"
+					stringWithZ := "aza"
+					Expect(MessageWithDiff(stringWithB, "to equal", stringWithZ)).Should(Equal(expectedDiffSmallThresholdZeroMismatch))
+				})
 			})
 		})
 	})
@@ -672,18 +730,34 @@ Expected
 to equal                 |
     <string>: "...tuvwxyz"
 `)
-
 var expectedFullFailureDiff = strings.TrimSpace(`
 Expected
     <string>: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 to equal
     <string>: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaazaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `)
-
 var expectedSpecialCharacterFailureMessage = strings.TrimSpace(`
 Expected
     <string>: \n
 to equal
     <string>: something_else
 
+`)
+var expectedDiffSmallThreshold = strings.TrimSpace(`
+Expected
+    <string>: "aba"
+to equal        |
+    <string>: "aza"
+`)
+var expectedDiffZeroMismatch = strings.TrimSpace(`
+Expected
+    <string>: aba
+to equal
+    <string>: aza
+`)
+var expectedDiffSmallThresholdZeroMismatch = strings.TrimSpace(`
+Expected
+    <string>: "...b..."
+to equal          |
+    <string>: "...z..."
 `)

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -192,6 +192,23 @@ var _ = Describe("Format", func() {
 		})
 
 		Context("With alternate diff lengths", func() {
+			initialValue := TruncateThreshold // 5 by default
+			BeforeEach(func() {
+				TruncateThreshold = 10000
+			})
+
+			AfterEach(func() {
+				TruncateThreshold = initialValue
+			})
+			It("should show the full diff", func() {
+				stringWithB := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+				stringWithZ := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaazaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+				Expect(MessageWithDiff(stringWithB, "to equal", stringWithZ)).Should(Equal(expectedFullFailureDiff))
+			})
+		})
+
+		Context("With alternate diff lengths", func() {
 			It("long strings that differ only in length", func() {
 				smallString := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 				largeString := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -204,7 +221,6 @@ var _ = Describe("Format", func() {
 				Expect(MessageWithDiff(smallString, "to equal", largeString)).Should(Equal(expectedTruncatedStartSizeSwappedFailureMessageExtraDiff))
 				CharactersAroundMismatchToInclude = initialValue
 			})
-
 		})
 	})
 

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -200,7 +200,7 @@ var _ = Describe("Format", func() {
 			AfterEach(func() {
 				TruncateThreshold = initialValue
 			})
-			It("should show the full diff", func() {
+			It("should show the full diff when truncate threshold is increased beyond length of strings", func() {
 				stringWithB := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 				stringWithZ := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaazaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
@@ -208,18 +208,21 @@ var _ = Describe("Format", func() {
 			})
 		})
 
-		Context("With alternate diff lengths", func() {
-			It("long strings that differ only in length", func() {
+		Context("with alternative number of characters to include around mismatch", func() {
+			initialValue := CharactersAroundMismatchToInclude // 5 by default
+			BeforeEach(func() {
+				CharactersAroundMismatchToInclude = 10
+			})
+
+			AfterEach(func() {
+				CharactersAroundMismatchToInclude = initialValue
+			})
+			It("it shows more characters around a line length mismatch", func() {
 				smallString := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 				largeString := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
-				Expect(MessageWithDiff(largeString, "to equal", smallString)).Should(Equal(expectedTruncatedStartSizeFailureMessage))
-				Expect(MessageWithDiff(smallString, "to equal", largeString)).Should(Equal(expectedTruncatedStartSizeSwappedFailureMessage))
-				initialValue := CharactersAroundMismatchToInclude // 5 by default
-				CharactersAroundMismatchToInclude = 10
 				Expect(MessageWithDiff(largeString, "to equal", smallString)).Should(Equal(expectedTruncatedStartSizeFailureMessageExtraDiff))
 				Expect(MessageWithDiff(smallString, "to equal", largeString)).Should(Equal(expectedTruncatedStartSizeSwappedFailureMessageExtraDiff))
-				CharactersAroundMismatchToInclude = initialValue
 			})
 		})
 	})

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -190,6 +190,22 @@ var _ = Describe("Format", func() {
 				Expect(MessageWithDiff(stringWithB, "to equal", stringWithZ)).Should(Equal(expectedFullFailureDiff))
 			})
 		})
+
+		Context("With alternate diff lengths", func() {
+			It("long strings that differ only in length", func() {
+				smallString := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+				largeString := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+				Expect(MessageWithDiff(largeString, "to equal", smallString)).Should(Equal(expectedTruncatedStartSizeFailureMessage))
+				Expect(MessageWithDiff(smallString, "to equal", largeString)).Should(Equal(expectedTruncatedStartSizeSwappedFailureMessage))
+				initialValue := CharactersAroundMismatchToInclude // 5 by default
+				CharactersAroundMismatchToInclude = 10
+				Expect(MessageWithDiff(largeString, "to equal", smallString)).Should(Equal(expectedTruncatedStartSizeFailureMessageExtraDiff))
+				Expect(MessageWithDiff(smallString, "to equal", largeString)).Should(Equal(expectedTruncatedStartSizeSwappedFailureMessageExtraDiff))
+				CharactersAroundMismatchToInclude = initialValue
+			})
+
+		})
 	})
 
 	Describe("IndentString", func() {
@@ -613,11 +629,23 @@ Expected
 to equal               |
     <string>: "...aaaaa"
 `)
+var expectedTruncatedStartSizeFailureMessageExtraDiff = strings.TrimSpace(`
+Expected
+    <string>: "...aaaaaaaaaaa"
+to equal                    |
+    <string>: "...aaaaaaaaaa"
+`)
 var expectedTruncatedStartSizeSwappedFailureMessage = strings.TrimSpace(`
 Expected
     <string>: "...aaaa"
 to equal              |
     <string>: "...aaaaa"
+`)
+var expectedTruncatedStartSizeSwappedFailureMessageExtraDiff = strings.TrimSpace(`
+Expected
+    <string>: "...aaaaaaaaa"
+to equal                   |
+    <string>: "...aaaaaaaaaa"
 `)
 var expectedTruncatedMultiByteFailureMessage = strings.TrimSpace(`
 Expected


### PR DESCRIPTION
Usually 5 characters of context around the diff location is enough, but it would be nice to be able to change that value as needed

https://github.com/onsi/gomega/issues/346