### PR TITLE
Simplify code

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -300,7 +300,7 @@ func formatString(object interface{}, indentation uint) string {
 			}
 		}
 
-		return fmt.Sprintf("%s", result)
+		return result
 	} else {
 		return fmt.Sprintf("%q", object)
 	}

--- a/matchers/receive_matcher_test.go
+++ b/matchers/receive_matcher_test.go
@@ -265,7 +265,7 @@ var _ = Describe("ReceiveMatcher", func() {
 	Describe("when used with eventually and a custom matcher", func() {
 		It("should return the matcher's error when a failing value is received on the channel, instead of the must receive something failure", func() {
 			failures := InterceptGomegaFailures(func() {
-				c := make(chan string, 0)
+				c := make(chan string)
 				Eventually(c, 0.01).Should(Receive(Equal("hello")))
 			})
 			Expect(failures[0]).Should(ContainSubstring("When passed a matcher, ReceiveMatcher's channel *must* receive something."))

--- a/matchers/support/goraph/bipartitegraph/bipartitegraph.go
+++ b/matchers/support/goraph/bipartitegraph/bipartitegraph.go
@@ -1,6 +1,5 @@
 package bipartitegraph
 
-import "errors"
 import "fmt"
 
 import . "github.com/onsi/gomega/matchers/support/goraph/node"
@@ -28,7 +27,7 @@ func NewBipartiteGraph(leftValues, rightValues []interface{}, neighbours func(in
 		for j, rightValue := range rightValues {
 			neighbours, err := neighbours(leftValue, rightValue)
 			if err != nil {
-				return nil, errors.New(fmt.Sprintf("error determining adjacency for %v and %v: %s", leftValue, rightValue, err.Error()))
+				return nil, fmt.Errorf("error determining adjacency for %v and %v: %s", leftValue, rightValue, err.Error())
 			}
 
 			if neighbours {


### PR DESCRIPTION
- Remove unnecessary fmt.Sprintf
- Use fmt.Errorf instead of errors.New(fmt.Sprintf(...))