### PR TITLE
Remove unnecessary conversions

### DIFF
--- a/matchers/match_xml_matcher_test.go
+++ b/matchers/match_xml_matcher_test.go
@@ -43,9 +43,7 @@ var _ = Describe("MatchXMLMatcher", func() {
 		})
 
 		It("should work with byte arrays", func() {
-			Expect([]byte(sample_01)).Should(MatchXML([]byte(sample_01)))
-			Expect([]byte(sample_01)).Should(MatchXML(sample_01))
-			Expect(sample_01).Should(MatchXML([]byte(sample_01)))
+			Expect(sample_01).Should(MatchXML(sample_01))
 		})
 	})
 


### PR DESCRIPTION
sample_01 is already a byte slice. Those conversions don't make any difference.