### PR TITLE
Support wrapped errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
 	golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e // indirect
 	golang.org/x/text v0.3.0 // indirect
+	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e h1:o3PsSEY8E4eXWkXrIP9YJALUk
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=

--- a/matchers/match_error_matcher_test.go
+++ b/matchers/match_error_matcher_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/matchers"
+	"golang.org/x/xerrors"
 )
 
 type CustomError struct {
@@ -18,16 +19,34 @@ func (c CustomError) Error() string {
 
 var _ = Describe("MatchErrorMatcher", func() {
 	Context("When asserting against an error", func() {
-		It("should succeed when matching with an error", func() {
-			err := errors.New("an error")
-			fmtErr := fmt.Errorf("an error")
-			customErr := CustomError{}
+		Context("when passed an error", func() {
+			It("should succeed when errors are deeply equal", func() {
+				err := errors.New("an error")
+				fmtErr := fmt.Errorf("an error")
+				customErr := CustomError{}
 
-			Expect(err).Should(MatchError(errors.New("an error")))
-			Expect(err).ShouldNot(MatchError(errors.New("another error")))
+				Expect(err).Should(MatchError(errors.New("an error")))
+				Expect(err).ShouldNot(MatchError(errors.New("another error")))
 
-			Expect(fmtErr).Should(MatchError(errors.New("an error")))
-			Expect(customErr).Should(MatchError(CustomError{}))
+				Expect(fmtErr).Should(MatchError(errors.New("an error")))
+				Expect(customErr).Should(MatchError(CustomError{}))
+			})
+
+			It("should succeed when any error in the chain matches the passed error", func() {
+				innerErr := errors.New("inner error")
+				outerErr := xerrors.Errorf("outer error wrapping: %w", innerErr)
+
+				Expect(outerErr).Should(MatchError(innerErr))
+			})
+		})
+
+		Context("when passed non-nil pointer to a type that implements error", func() {
+			It("should succeed when any error in the chain matches the passed pointer", func() {
+				err := xerrors.Errorf("outer error wrapping: %w", CustomError{})
+
+				var expectedErrType CustomError
+				Expect(err).Should(MatchError(&expectedErrType))
+			})
 		})
 
 		It("should succeed when matching with a string", func() {


### PR DESCRIPTION
This PR is a suggestion how to assert wrapped errors (see #334).

It covers two related but different use cases:
1. Test whether an error wraps another error.
2. Test whether an error wraps another error of a specific type.

Instead of having separate matchers for wrapped errors, the existing `MatchError` matcher is extended to test for `errors.Is()` and `errors.As()`.

**Rationale:**
I think it makes sense to really test against `errors.Is()` and `errors.As()` instead of "only" testing for wrapped errors as a `WrapError` matcher would do since `Is()` and `As()` can return `true` although there are no wrapped errors at all.

I also think that it makes sense to test `errors.Is()` within the existing `MatchError` matcher instead of having an additional matcher which would be named like `BeError` since it would sound confusing to the user what the difference is between `MatchError` and `BeError`.

(One possibility is to extract the test for `errors.As()` into a separate matcher which would be named something like `WrapOrBeAssignableToTypeOf`. However, this also doesn't sound very clear.)
