### PR TITLE
Allow optional description to be lazily evaluated function

### DIFF
--- a/gomega_dsl.go
+++ b/gomega_dsl.go
@@ -293,16 +293,18 @@ func SetDefaultConsistentlyPollingInterval(t time.Duration) {
 // AsyncAssertion is returned by Eventually and Consistently and polls the actual value passed into Eventually against
 // the matcher passed to the Should and ShouldNot methods.
 //
-// Both Should and ShouldNot take a variadic optionalDescription argument.  This is passed on to
-// fmt.Sprintf() and is used to annotate failure messages.  This allows you to make your failure messages more
-// descriptive.
+// Both Should and ShouldNot take a variadic optionalDescription argument.
+// This argument allows you to make your failure messages more descriptive.
+// If a single argument of type `func() string` is passed, this function will be lazily evaluated if a failure occurs
+// and the returned string is used to annotate the failure message.
+// Otherwise, this argument is passed on to fmt.Sprintf() and then used to annotate the failure message.
 //
 // Both Should and ShouldNot return a boolean that is true if the assertion passed and false if it failed.
 //
 // Example:
 //
 //   Eventually(myChannel).Should(Receive(), "Something should have come down the pipe.")
-//   Consistently(myChannel).ShouldNot(Receive(), "Nothing should have come down the pipe.")
+//   Consistently(myChannel).ShouldNot(Receive(), func() string { return "Nothing should have come down the pipe." })
 type AsyncAssertion interface {
 	Should(matcher types.GomegaMatcher, optionalDescription ...interface{}) bool
 	ShouldNot(matcher types.GomegaMatcher, optionalDescription ...interface{}) bool
@@ -317,8 +319,11 @@ type GomegaAsyncAssertion = AsyncAssertion
 // Typically Should/ShouldNot are used with Ω and To/ToNot/NotTo are used with Expect
 // though this is not enforced.
 //
-// All methods take a variadic optionalDescription argument.  This is passed on to fmt.Sprintf()
-// and is used to annotate failure messages.
+// All methods take a variadic optionalDescription argument.
+// This argument allows you to make your failure messages more descriptive.
+// If a single argument of type `func() string` is passed, this function will be lazily evaluated if a failure occurs
+// and the returned string is used to annotate the failure message.
+// Otherwise, this argument is passed on to fmt.Sprintf() and then used to annotate the failure message.
 //
 // All methods return a bool that is true if the assertion passed and false if it failed.
 //

--- a/internal/assertion/assertion.go
+++ b/internal/assertion/assertion.go
@@ -49,11 +49,13 @@ func (assertion *Assertion) NotTo(matcher types.GomegaMatcher, optionalDescripti
 }
 
 func (assertion *Assertion) buildDescription(optionalDescription ...interface{}) string {
-	if len(optionalDescription) == 0 {
+	switch len(optionalDescription) {
+	case 0:
 		return ""
-	}
-	if describe, ok := optionalDescription[0].(func() string); ok && len(optionalDescription) == 1 {
-		return describe() + "\n"
+	case 1:
+		if describe, ok := optionalDescription[0].(func() string); ok {
+			return describe() + "\n"
+		}
 	}
 	return fmt.Sprintf(optionalDescription[0].(string), optionalDescription[1:]...) + "\n"
 }

--- a/internal/assertion/assertion_test.go
+++ b/internal/assertion/assertion_test.go
@@ -95,6 +95,17 @@ var _ = Describe("Assertion", func() {
 				Expect(a.ShouldNot(matcher)).Should(BeFalse())
 			})
 		})
+
+		Context("and the optional description is a function", func() {
+			It("should not evaluate that function", func() {
+				evaluated := false
+				a.Should(matcher, func() string {
+					evaluated = true
+					return "A description"
+				})
+				Expect(evaluated).Should(BeFalse())
+			})
+		})
 	})
 
 	Context("when the matcher fails", func() {
@@ -145,6 +156,14 @@ var _ = Describe("Assertion", func() {
 			It("should append the formatted description to the failure message", func() {
 				a.Should(matcher, "A description of [%d]", 3)
 				Expect(failureMessage).Should(Equal("A description of [3]\npositive: The thing I'm testing"))
+				Expect(failureCallerSkip).Should(Equal(3))
+			})
+		})
+
+		Context("and the optional description is a function", func() {
+			It("should append the description to the failure message", func() {
+				a.Should(matcher, func() string { return "A description" })
+				Expect(failureMessage).Should(Equal("A description\npositive: The thing I'm testing"))
 				Expect(failureCallerSkip).Should(Equal(3))
 			})
 		})

--- a/internal/asyncassertion/async_assertion.go
+++ b/internal/asyncassertion/async_assertion.go
@@ -57,12 +57,13 @@ func (assertion *AsyncAssertion) ShouldNot(matcher types.GomegaMatcher, optional
 }
 
 func (assertion *AsyncAssertion) buildDescription(optionalDescription ...interface{}) string {
-	switch len(optionalDescription) {
-	case 0:
+	if len(optionalDescription) == 0 {
 		return ""
-	default:
-		return fmt.Sprintf(optionalDescription[0].(string), optionalDescription[1:]...) + "\n"
 	}
+	if describe, ok := optionalDescription[0].(func() string); ok && len(optionalDescription) == 1 {
+		return describe() + "\n"
+	}
+	return fmt.Sprintf(optionalDescription[0].(string), optionalDescription[1:]...) + "\n"
 }
 
 func (assertion *AsyncAssertion) actualInputIsAFunction() bool {
@@ -103,8 +104,6 @@ func (assertion *AsyncAssertion) match(matcher types.GomegaMatcher, desiredMatch
 	timer := time.Now()
 	timeout := time.After(assertion.timeoutInterval)
 
-	description := assertion.buildDescription(optionalDescription...)
-
 	var matches bool
 	var err error
 	mayChange := true
@@ -129,6 +128,7 @@ func (assertion *AsyncAssertion) match(matcher types.GomegaMatcher, desiredMatch
 			}
 		}
 		assertion.failWrapper.TWithHelper.Helper()
+		description := assertion.buildDescription(optionalDescription...)
 		assertion.failWrapper.Fail(fmt.Sprintf("%s after %.3fs.\n%s%s%s", preamble, time.Since(timer).Seconds(), description, message, errMsg), 3+assertion.offset)
 	}
 

--- a/internal/asyncassertion/async_assertion.go
+++ b/internal/asyncassertion/async_assertion.go
@@ -57,11 +57,13 @@ func (assertion *AsyncAssertion) ShouldNot(matcher types.GomegaMatcher, optional
 }
 
 func (assertion *AsyncAssertion) buildDescription(optionalDescription ...interface{}) string {
-	if len(optionalDescription) == 0 {
+	switch len(optionalDescription) {
+	case 0:
 		return ""
-	}
-	if describe, ok := optionalDescription[0].(func() string); ok && len(optionalDescription) == 1 {
-		return describe() + "\n"
+	case 1:
+		if describe, ok := optionalDescription[0].(func() string); ok {
+			return describe() + "\n"
+		}
 	}
 	return fmt.Sprintf(optionalDescription[0].(string), optionalDescription[1:]...) + "\n"
 }


### PR DESCRIPTION
As suggested in #193 and #351, allow a single argument of type `func() string` to be passed as an optional description. This function gets lazily evaluated if there's a failure and the returned string is used to annotate the failure message.