### PR TITLE
ConsistOf matcher failure output: add missing and extra elements

### DIFF
--- a/matchers/consist_of_test.go
+++ b/matchers/consist_of_test.go
@@ -72,4 +72,39 @@ var _ = Describe("ConsistOf", func() {
 			Expect([]string{"foo", "bar", "baz"}).Should(ConsistOf([]string{"foo", "bar", "baz"}))
 		})
 	})
+
+	Describe("FailureMessage", func() {
+		When("actual contains an extra element", func() {
+			It("prints the extra element", func() {
+				failures := InterceptGomegaFailures(func() {
+					Expect([]int{1, 2}).Should(ConsistOf(2))
+				})
+
+				expected := "Expected\n.*\\[1, 2\\]\nto consist of\n.*\\[2\\]\nthe extra elements were\n.*\\[1\\]"
+				Expect(failures).To(ConsistOf(MatchRegexp(expected)))
+			})
+		})
+
+		When("actual misses an element", func() {
+			It("prints the missing element", func() {
+				failures := InterceptGomegaFailures(func() {
+					Expect([]int{2}).Should(ConsistOf(1, 2))
+				})
+
+				expected := "Expected\n.*\\[2\\]\nto consist of\n.*\\[1, 2\\]\nthe missing elements were\n.*\\[1\\]"
+				Expect(failures).To(ConsistOf(MatchRegexp(expected)))
+			})
+		})
+
+		When("actual contains an extra element and misses an element", func() {
+			It("prints both the extra and missing element", func() {
+				failures := InterceptGomegaFailures(func() {
+					Expect([]int{1, 2}).Should(ConsistOf(2, 3))
+				})
+
+				expected := "Expected\n.*\\[1, 2\\]\nto consist of\n.*\\[2, 3\\]\nthe missing elements were\n.*\\[3\\]\nthe extra elements were\n.*\\[1\\]"
+				Expect(failures).To(ConsistOf(MatchRegexp(expected)))
+			})
+		})
+	})
 })

--- a/matchers/support/goraph/bipartitegraph/bipartitegraph.go
+++ b/matchers/support/goraph/bipartitegraph/bipartitegraph.go
@@ -13,13 +13,13 @@ type BipartiteGraph struct {
 
 func NewBipartiteGraph(leftValues, rightValues []interface{}, neighbours func(interface{}, interface{}) (bool, error)) (*BipartiteGraph, error) {
 	left := NodeOrderedSet{}
-	for i := range leftValues {
-		left = append(left, Node{Id: i})
+	for i, v := range leftValues {
+		left = append(left, Node{ID: i, Value: v})
 	}
 
 	right := NodeOrderedSet{}
-	for j := range rightValues {
-		right = append(right, Node{Id: j + len(left)})
+	for j, v := range rightValues {
+		right = append(right, Node{ID: j + len(left), Value: v})
 	}
 
 	edges := EdgeSet{}
@@ -31,10 +31,26 @@ func NewBipartiteGraph(leftValues, rightValues []interface{}, neighbours func(in
 			}
 
 			if neighbours {
-				edges = append(edges, Edge{Node1: left[i], Node2: right[j]})
+				edges = append(edges, Edge{Node1: left[i].ID, Node2: right[j].ID})
 			}
 		}
 	}
 
 	return &BipartiteGraph{left, right, edges}, nil
+}
+
+// FreeLeftRight returns left node values and right node values
+// of the BipartiteGraph's nodes which are not part of the given edges.
+func (bg *BipartiteGraph) FreeLeftRight(edges EdgeSet) (leftValues, rightValues []interface{}) {
+	for _, node := range bg.Left {
+		if edges.Free(node) {
+			leftValues = append(leftValues, node.Value)
+		}
+	}
+	for _, node := range bg.Right {
+		if edges.Free(node) {
+			rightValues = append(rightValues, node.Value)
+		}
+	}
+	return
 }

--- a/matchers/support/goraph/bipartitegraph/bipartitegraph_suite_test.go
+++ b/matchers/support/goraph/bipartitegraph/bipartitegraph_suite_test.go
@@ -1,0 +1,13 @@
+package bipartitegraph_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestBipartitegraph(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Bipartitegraph Suite")
+}

--- a/matchers/support/goraph/bipartitegraph/bipartitegraph_test.go
+++ b/matchers/support/goraph/bipartitegraph/bipartitegraph_test.go
@@ -1,0 +1,125 @@
+package bipartitegraph_test
+
+import (
+	. "github.com/onsi/gomega/matchers/support/goraph/bipartitegraph"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Bipartitegraph", func() {
+	Context("tiny graphs", func() {
+		var (
+			empty, _        = NewBipartiteGraph([]interface{}{}, []interface{}{}, func(x, y interface{}) (bool, error) { return true, nil })
+			oneLeft, _      = NewBipartiteGraph([]interface{}{1}, []interface{}{}, func(x, y interface{}) (bool, error) { return true, nil })
+			oneRight, _     = NewBipartiteGraph([]interface{}{}, []interface{}{1}, func(x, y interface{}) (bool, error) { return true, nil })
+			twoSeparate, _  = NewBipartiteGraph([]interface{}{1}, []interface{}{1}, func(x, y interface{}) (bool, error) { return false, nil })
+			twoConnected, _ = NewBipartiteGraph([]interface{}{1}, []interface{}{1}, func(x, y interface{}) (bool, error) { return true, nil })
+		)
+
+		It("Computes the correct largest matching", func() {
+			Ω(empty.LargestMatching()).Should(BeEmpty())
+			Ω(oneLeft.LargestMatching()).Should(BeEmpty())
+			Ω(oneRight.LargestMatching()).Should(BeEmpty())
+			Ω(twoSeparate.LargestMatching()).Should(BeEmpty())
+
+			Ω(twoConnected.LargestMatching()).Should(HaveLen(1))
+		})
+	})
+
+	Context("small yet complex graphs", func() {
+		var (
+			neighbours = func(x, y interface{}) (bool, error) {
+				switch x.(string) + y.(string) {
+				case "aw", "bw", "bx", "cy", "cz", "dx", "ew":
+					return true, nil
+				default:
+					return false, nil
+				}
+			}
+			graph, _ = NewBipartiteGraph(
+				[]interface{}{"a", "b", "c", "d", "e"},
+				[]interface{}{"w", "x", "y", "z"},
+				neighbours,
+			)
+		)
+
+		It("Computes the correct largest matching", func() {
+			Ω(graph.LargestMatching()).Should(HaveLen(3))
+		})
+	})
+
+	Context("large yet simple graphs", func() {
+		var (
+			half                = make([]interface{}, 100)
+			discreteNeighbours  = func(x, y interface{}) (bool, error) { return false, nil }
+			completeNeighbours  = func(x, y interface{}) (bool, error) { return true, nil }
+			bijectionNeighbours = func(x, y interface{}) (bool, error) {
+				return x.(int) == y.(int), nil
+			}
+			discrete, complete, bijection *BipartiteGraph
+		)
+
+		BeforeEach(func() {
+			for i := 0; i < len(half); i++ {
+				half[i] = i
+			}
+			discrete, _ = NewBipartiteGraph(half, half, discreteNeighbours)
+			complete, _ = NewBipartiteGraph(half, half, completeNeighbours)
+			bijection, _ = NewBipartiteGraph(half, half, bijectionNeighbours)
+		})
+
+		It("Computes the correct largest matching", func() {
+			Ω(discrete.LargestMatching()).Should(BeEmpty())
+			Ω(complete.LargestMatching()).Should(HaveLen(100))
+			Ω(bijection.LargestMatching()).Should(HaveLen(100))
+		})
+	})
+
+	Context("large graphs that are unpleasant for the algorithm", func() {
+		var (
+			half        = make([]interface{}, 100)
+			neighbours1 = func(x, y interface{}) (bool, error) {
+				if x.(int) < 33 {
+					return x.(int) == y.(int), nil
+				} else if x.(int) < 66 {
+					return true, nil
+				} else {
+					return false, nil
+				}
+			}
+			neighbours2 = func(x, y interface{}) (bool, error) {
+				if x.(int) == 50 {
+					return true, nil
+				} else if x.(int) < 90 {
+					return x.(int) == y.(int), nil
+				} else {
+					return false, nil
+				}
+			}
+			neighbours3 = func(x, y interface{}) (bool, error) {
+				if y.(int) < x.(int)-20 {
+					return true, nil
+				} else {
+					return false, nil
+				}
+			}
+			graph1, graph2, graph3 *BipartiteGraph
+		)
+
+		BeforeEach(func() {
+			for i := 0; i < len(half); i++ {
+				half[i] = i
+			}
+			graph1, _ = NewBipartiteGraph(half, half, neighbours1)
+			graph2, _ = NewBipartiteGraph(half, half, neighbours2)
+			graph3, _ = NewBipartiteGraph(half, half, neighbours3)
+		})
+
+		It("Computes the correct largest matching", func() {
+			Ω(graph1.LargestMatching()).Should(HaveLen(66))
+			Ω(graph2.LargestMatching()).Should(HaveLen(90))
+			Ω(graph3.LargestMatching()).Should(HaveLen(79))
+		})
+	})
+})

--- a/matchers/support/goraph/bipartitegraph/bipartitegraph_test.go
+++ b/matchers/support/goraph/bipartitegraph/bipartitegraph_test.go
@@ -1,6 +1,8 @@
 package bipartitegraph_test
 
 import (
+	"reflect"
+
 	. "github.com/onsi/gomega/matchers/support/goraph/bipartitegraph"
 
 	. "github.com/onsi/ginkgo"
@@ -45,7 +47,48 @@ var _ = Describe("Bipartitegraph", func() {
 		)
 
 		It("Computes the correct largest matching", func() {
+			// largest matching: "aw", "bx", "cy"
 			Ω(graph.LargestMatching()).Should(HaveLen(3))
+		})
+
+		Describe("FreeLeftRight", func() {
+			When("all edges are given", func() {
+				It("returns correct free left and right values", func() {
+					freeLeft, freeRight := graph.FreeLeftRight(graph.Edges)
+					Expect(freeLeft).To(BeEmpty())
+					Expect(freeRight).To(BeEmpty())
+				})
+			})
+			When("largest matching edges are given", func() {
+				It("returns correct free left and right values", func() {
+					edges := graph.LargestMatching()
+					freeLeft, freeRight := graph.FreeLeftRight(edges)
+					Expect(freeLeft).To(ConsistOf("d", "e"))
+					Expect(freeRight).To(ConsistOf("z"))
+				})
+			})
+		})
+	})
+
+	When("node values are unhashable types", func() {
+		var (
+			neighbours = func(x, y interface{}) (bool, error) {
+				return reflect.DeepEqual(x, y), nil
+			}
+			graph, _ = NewBipartiteGraph(
+				[]interface{}{[]int{1, 2}, []int{3, 4}},
+				[]interface{}{[]int{1, 2}},
+				neighbours,
+			)
+		)
+		Describe("FreeLeftRight", func() {
+			It("returns correct free left and right values", func() {
+				edges := graph.LargestMatching()
+				freeLeft, freeRight := graph.FreeLeftRight(edges)
+				Expect(freeLeft).To(HaveLen(1))
+				Expect(freeLeft[0]).To(Equal([]int{3, 4}))
+				Expect(freeRight).To(BeEmpty())
+			})
 		})
 	})
 

--- a/matchers/support/goraph/bipartitegraph/bipartitegraphmatching.go
+++ b/matchers/support/goraph/bipartitegraph/bipartitegraphmatching.go
@@ -4,6 +4,9 @@ import . "github.com/onsi/gomega/matchers/support/goraph/node"
 import . "github.com/onsi/gomega/matchers/support/goraph/edge"
 import "github.com/onsi/gomega/matchers/support/goraph/util"
 
+// LargestMatching implements the Hopcroft–Karp algorithm taking as input a bipartite graph
+// and outputting a maximum cardinality matching, i.e. a set of as many edges as possible
+// with the property that no two edges share an endpoint.
 func (bg *BipartiteGraph) LargestMatching() (matching EdgeSet) {
 	paths := bg.maximalDisjointSLAPCollection(matching)
 

--- a/matchers/support/goraph/bipartitegraph/bipartitegraphmatching.go
+++ b/matchers/support/goraph/bipartitegraph/bipartitegraphmatching.go
@@ -1,8 +1,10 @@
 package bipartitegraph
 
-import . "github.com/onsi/gomega/matchers/support/goraph/node"
-import . "github.com/onsi/gomega/matchers/support/goraph/edge"
-import "github.com/onsi/gomega/matchers/support/goraph/util"
+import (
+	. "github.com/onsi/gomega/matchers/support/goraph/edge"
+	. "github.com/onsi/gomega/matchers/support/goraph/node"
+	"github.com/onsi/gomega/matchers/support/goraph/util"
+)
 
 // LargestMatching implements the Hopcroft–Karp algorithm taking as input a bipartite graph
 // and outputting a maximum cardinality matching, i.e. a set of as many edges as possible
@@ -26,7 +28,7 @@ func (bg *BipartiteGraph) maximalDisjointSLAPCollection(matching EdgeSet) (resul
 		return
 	}
 
-	used := make(map[Node]bool)
+	used := make(map[int]bool)
 
 	for _, u := range guideLayers[len(guideLayers)-1] {
 		slap, found := bg.findDisjointSLAP(u, matching, guideLayers, used)
@@ -46,7 +48,7 @@ func (bg *BipartiteGraph) findDisjointSLAP(
 	start Node,
 	matching EdgeSet,
 	guideLayers []NodeOrderedSet,
-	used map[Node]bool,
+	used map[int]bool,
 ) ([]Edge, bool) {
 	return bg.findDisjointSLAPHelper(start, EdgeSet{}, len(guideLayers)-1, matching, guideLayers, used)
 }
@@ -57,16 +59,16 @@ func (bg *BipartiteGraph) findDisjointSLAPHelper(
 	currentLevel int,
 	matching EdgeSet,
 	guideLayers []NodeOrderedSet,
-	used map[Node]bool,
+	used map[int]bool,
 ) (EdgeSet, bool) {
-	used[currentNode] = true
+	used[currentNode.ID] = true
 
 	if currentLevel == 0 {
 		return currentSLAP, true
 	}
 
 	for _, nextNode := range guideLayers[currentLevel-1] {
-		if used[nextNode] {
+		if used[nextNode.ID] {
 			continue
 		}
 
@@ -87,17 +89,17 @@ func (bg *BipartiteGraph) findDisjointSLAPHelper(
 		currentSLAP = currentSLAP[:len(currentSLAP)-1]
 	}
 
-	used[currentNode] = false
+	used[currentNode.ID] = false
 	return nil, false
 }
 
 func (bg *BipartiteGraph) createSLAPGuideLayers(matching EdgeSet) (guideLayers []NodeOrderedSet) {
-	used := make(map[Node]bool)
+	used := make(map[int]bool)
 	currentLayer := NodeOrderedSet{}
 
 	for _, node := range bg.Left {
 		if matching.Free(node) {
-			used[node] = true
+			used[node.ID] = true
 			currentLayer = append(currentLayer, node)
 		}
 	}
@@ -116,7 +118,7 @@ func (bg *BipartiteGraph) createSLAPGuideLayers(matching EdgeSet) (guideLayers [
 		if util.Odd(len(guideLayers)) {
 			for _, leftNode := range lastLayer {
 				for _, rightNode := range bg.Right {
-					if used[rightNode] {
+					if used[rightNode.ID] {
 						continue
 					}
 
@@ -126,7 +128,7 @@ func (bg *BipartiteGraph) createSLAPGuideLayers(matching EdgeSet) (guideLayers [
 					}
 
 					currentLayer = append(currentLayer, rightNode)
-					used[rightNode] = true
+					used[rightNode.ID] = true
 
 					if matching.Free(rightNode) {
 						done = true
@@ -136,7 +138,7 @@ func (bg *BipartiteGraph) createSLAPGuideLayers(matching EdgeSet) (guideLayers [
 		} else {
 			for _, rightNode := range lastLayer {
 				for _, leftNode := range bg.Left {
-					if used[leftNode] {
+					if used[leftNode.ID] {
 						continue
 					}
 
@@ -146,7 +148,7 @@ func (bg *BipartiteGraph) createSLAPGuideLayers(matching EdgeSet) (guideLayers [
 					}
 
 					currentLayer = append(currentLayer, leftNode)
-					used[leftNode] = true
+					used[leftNode.ID] = true
 				}
 			}
 

--- a/matchers/support/goraph/edge/edge.go
+++ b/matchers/support/goraph/edge/edge.go
@@ -3,15 +3,15 @@ package edge
 import . "github.com/onsi/gomega/matchers/support/goraph/node"
 
 type Edge struct {
-	Node1 Node
-	Node2 Node
+	Node1 int
+	Node2 int
 }
 
 type EdgeSet []Edge
 
 func (ec EdgeSet) Free(node Node) bool {
 	for _, e := range ec {
-		if e.Node1 == node || e.Node2 == node {
+		if e.Node1 == node.ID || e.Node2 == node.ID {
 			return false
 		}
 	}
@@ -31,7 +31,7 @@ func (ec EdgeSet) Contains(edge Edge) bool {
 
 func (ec EdgeSet) FindByNodes(node1, node2 Node) (Edge, bool) {
 	for _, e := range ec {
-		if (e.Node1 == node1 && e.Node2 == node2) || (e.Node1 == node2 && e.Node2 == node1) {
+		if (e.Node1 == node1.ID && e.Node2 == node2.ID) || (e.Node1 == node2.ID && e.Node2 == node1.ID) {
 			return e, true
 		}
 	}

--- a/matchers/support/goraph/node/node.go
+++ b/matchers/support/goraph/node/node.go
@@ -1,7 +1,8 @@
 package node
 
 type Node struct {
-	Id int
+	ID    int
+	Value interface{}
 }
 
 type NodeOrderedSet []Node


### PR DESCRIPTION
Resolves #368.

```golang
var _ = Describe("foo", func() {
	It("bar", func() {
		Expect([]int{1, 2, 3}).To(ConsistOf(2, 3, 4))
	})
})
```
will output
```
  Expected
      <[]int | len:3, cap:3>: [1, 2, 3]
  to consist of
      <[]interface {} | len:3, cap:3>: [2, 3, 4]
  the missing elements were
      <[]interface {} | len:1, cap:1>: [4]
  the extra elements were
      <[]interface {} | len:1, cap:1>: [1]
```