### PR TITLE
Change JSONRepresenting matcher to check MIME type

### DIFF
--- a/ghttp/handlers.go
+++ b/ghttp/handlers.go
@@ -137,7 +137,7 @@ func VerifyJSONRepresenting(object interface{}) http.HandlerFunc {
 	data, err := json.Marshal(object)
 	Expect(err).ShouldNot(HaveOccurred())
 	return CombineHandlers(
-		VerifyContentType("application/json"),
+		VerifyMimeType("application/json"),
 		VerifyJSON(string(data)),
 	)
 }


### PR DESCRIPTION
This brings `VerifyJSONRepresenting` inline with `VerifyJSON`.

Can add tests if we decide this is the correct way to go.