### PR TITLE
Add dockerfile and docker-compose for build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.15
+
+RUN go get github.com/onsi/ginkgo/ginkgo
+RUN go install github.com/onsi/ginkgo/ginkgo

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
+
+.PHONY: test
 test:
 	[ -z "`gofmt -s -w -l -e .`" ]
 	go vet
 	ginkgo -p -r --randomizeAllSpecs --failOnPending --randomizeSuites --race
 
-.PHONY: test
+docker_test:
+	docker-compose build test && docker-compose run --rm test make test

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: '3.0'
+
+services:
+  test:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    working_dir: /app
+    volumes:
+      - ${PWD}:/app


### PR DESCRIPTION
Now a contributor can run `make test` without requiring a `go` installed or `ginkgo` package.