### PR TITLE
Fix a panic in MessageWithDiff with long message

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -105,7 +105,13 @@ func MessageWithDiff(actual, message, expected string) string {
 
 		tabLength := 4
 		spaceFromMessageToActual := tabLength + len("<string>: ") - len(message)
-		padding := strings.Repeat(" ", spaceFromMessageToActual+spacesBeforeFormattedMismatch) + "|"
+
+		paddingCount := spaceFromMessageToActual + spacesBeforeFormattedMismatch
+		if paddingCount < 0 {
+			return Message(formattedActual, message, formattedExpected)
+		}
+
+		padding := strings.Repeat(" ", paddingCount) + "|"
 		return Message(formattedActual, message+padding, formattedExpected)
 	}
 

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -174,6 +174,14 @@ var _ = Describe("Format", func() {
 			Expect(MessageWithDiff(stringA, "to equal", stringB)).Should(Equal(expectedSpecialCharacterFailureMessage))
 		})
 
+		It("handles negative padding length", func() {
+			stringWithB := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			stringWithZ := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaazaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			longMessage := "to equal very long message"
+
+			Expect(MessageWithDiff(stringWithB, longMessage, stringWithZ)).Should(Equal(expectedDiffLongMessage))
+		})
+
 		Context("With truncated diff disabled", func() {
 			BeforeEach(func() {
 				TruncatedDiff = false
@@ -760,4 +768,11 @@ Expected
     <string>: "...b..."
 to equal          |
     <string>: "...z..."
+`)
+
+var expectedDiffLongMessage = strings.TrimSpace(`
+Expected
+    <string>: "...aaaaabaaaaa..."
+to equal very long message
+    <string>: "...aaaaazaaaaa..."
 `)


### PR DESCRIPTION
Fixes #401

In such cases `MessageWithDiff` would fallback to `Message` without padding.