### PR TITLE
fix: collections matchers should display type of expectation

### DIFF
--- a/matchers/consist_of_test.go
+++ b/matchers/consist_of_test.go
@@ -127,5 +127,55 @@ var _ = Describe("ConsistOf", func() {
 				Expect(failures).To(ConsistOf(MatchRegexp(expected)))
 			})
 		})
+
+		When("the expected values are the same type", func() {
+			It("uses that type for the expectation slice", func() {
+				failures := InterceptGomegaFailures(func() {
+					Expect([]string{"A", "B"}).To(ConsistOf("A", "C"))
+				})
+
+				expected := `to consist of
+\s*<\[\]string \| len:2, cap:2>: \["A", "C"\]
+the missing elements were
+\s*<\[\]string \| len:1, cap:1>: \["C"\]
+the extra elements were
+\s*<\[\]string \| len:1, cap:1>: \["B"\]`
+				Expect(failures).To(ConsistOf(MatchRegexp(expected)))
+			})
+
+			It("uses that type for the negated expectation slice", func() {
+				failures := InterceptGomegaFailures(func() {
+					Expect([]uint64{1, 2}).NotTo(ConsistOf(uint64(1), uint64(2)))
+				})
+
+				expected := `not to consist of\n\s*<\[\]uint64 \| len:2, cap:2>: \[1, 2\]`
+				Expect(failures).To(ConsistOf(MatchRegexp(expected)))
+			})
+		})
+
+		When("the expected values are different types", func() {
+			It("uses interface{} for the expectation slice", func() {
+				failures := InterceptGomegaFailures(func() {
+					Expect([]interface{}{1, true}).To(ConsistOf(1, "C"))
+				})
+
+				expected := `to consist of
+\s*<\[\]interface {} \| len:2, cap:2>: \[1, "C"\]
+the missing elements were
+\s*<\[\]string \| len:1, cap:1>: \["C"\]
+the extra elements were
+\s*<\[\]bool \| len:1, cap:1>: \[true\]`
+				Expect(failures).To(ConsistOf(MatchRegexp(expected)))
+			})
+
+			It("uses interface{} for the negated expectation slice", func() {
+				failures := InterceptGomegaFailures(func() {
+					Expect([]interface{}{1, "B"}).NotTo(ConsistOf(1, "B"))
+				})
+
+				expected := `not to consist of\n\s*<\[\]interface {} \| len:2, cap:2>: \[1, "B"\]`
+				Expect(failures).To(ConsistOf(MatchRegexp(expected)))
+			})
+		})
 	})
 })

--- a/matchers/contain_elements_matcher.go
+++ b/matchers/contain_elements_matcher.go
@@ -35,10 +35,10 @@ func (matcher *ContainElementsMatcher) Match(actual interface{}) (success bool, 
 }
 
 func (matcher *ContainElementsMatcher) FailureMessage(actual interface{}) (message string) {
-	message = format.Message(actual, "to contain elements", flatten(matcher.Elements))
+	message = format.Message(actual, "to contain elements", presentable(matcher.Elements))
 	return appendMissingElements(message, matcher.missingElements)
 }
 
 func (matcher *ContainElementsMatcher) NegatedFailureMessage(actual interface{}) (message string) {
-	return format.Message(actual, "not to contain elements", flatten(matcher.Elements))
+	return format.Message(actual, "not to contain elements", presentable(matcher.Elements))
 }

--- a/matchers/contain_elements_matcher_test.go
+++ b/matchers/contain_elements_matcher_test.go
@@ -102,5 +102,51 @@ var _ = Describe("ContainElements", func() {
 				Expect(failures).To(ConsistOf(MatchRegexp(expected)))
 			})
 		})
+
+		When("the expected values are the same type", func() {
+			It("uses that type for the expectation slice", func() {
+				failures := InterceptGomegaFailures(func() {
+					Expect([]string{"A", "B"}).To(ContainElements("A", "B", "C"))
+				})
+
+				expected := `to contain elements
+\s*<\[\]string \| len:3, cap:3>: \["A", "B", "C"\]
+the missing elements were
+\s*<\[\]string \| len:1, cap:1>: \["C"\]`
+				Expect(failures).To(ConsistOf(MatchRegexp(expected)))
+			})
+
+			It("uses that type for the negated expectation slice", func() {
+				failures := InterceptGomegaFailures(func() {
+					Expect([]uint64{1, 2}).NotTo(ContainElements(uint64(1), uint64(2)))
+				})
+
+				expected := `not to contain elements\n\s*<\[\]uint64 \| len:2, cap:2>: \[1, 2\]`
+				Expect(failures).To(ConsistOf(MatchRegexp(expected)))
+			})
+		})
+
+		When("the expected values are different types", func() {
+			It("uses interface{} for the expectation slice", func() {
+				failures := InterceptGomegaFailures(func() {
+					Expect([]interface{}{1, true}).To(ContainElements(1, "C"))
+				})
+
+				expected := `to contain elements
+\s*<\[\]interface {} \| len:2, cap:2>: \[1, "C"\]
+the missing elements were
+\s*<\[\]string \| len:1, cap:1>: \["C"\]`
+				Expect(failures).To(ConsistOf(MatchRegexp(expected)))
+			})
+
+			It("uses interface{} for the negated expectation slice", func() {
+				failures := InterceptGomegaFailures(func() {
+					Expect([]interface{}{1, "B"}).NotTo(ContainElements(1, "B"))
+				})
+
+				expected := `not to contain elements\n\s*<\[\]interface {} \| len:2, cap:2>: \[1, "B"\]`
+				Expect(failures).To(ConsistOf(MatchRegexp(expected)))
+			})
+		})
 	})
 })


### PR DESCRIPTION
The collections matchers ConsistOf() and ContainElements() are often
used with collections of consistent type, for example:

Expect(t).To(ConsistOf(1, 2, 3))

When this fails, it's more helpful to report:

   ...to contain elements <[]int | len:3, cap:3>: [1, 2, 3]

Than the previous behavior:

   ...to contain elements <[]interface {} | len:3, cap:3>: [1, 2, 3]

By using []interface{} only where there's no other option we make it
easier to debug issues - especially for types that display identically.