### PR TITLE
fix: print value type for interface{} containers

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -271,7 +271,7 @@ func formatValue(value reflect.Value, indentation uint) string {
 		}
 		return formatStruct(value, indentation)
 	case reflect.Interface:
-		return formatValue(value.Elem(), indentation)
+		return formatInterface(value, indentation)
 	default:
 		if value.CanInterface() {
 			return fmt.Sprintf("%#v", value.Interface())
@@ -364,6 +364,10 @@ func formatStruct(v reflect.Value, indentation uint) string {
 		return fmt.Sprintf("{\n%s%s,\n%s}", indenter+Indent, strings.Join(result, ",\n"+indenter+Indent), indenter)
 	}
 	return fmt.Sprintf("{%s}", strings.Join(result, ", "))
+}
+
+func formatInterface(v reflect.Value, indentation uint) string {
+	return fmt.Sprintf("<%s>%s", formatType(v.Elem()), formatValue(v.Elem(), indentation))
 }
 
 func isNilValue(a reflect.Value) bool {

--- a/matchers/consist_of_test.go
+++ b/matchers/consist_of_test.go
@@ -160,7 +160,7 @@ the extra elements were
 				})
 
 				expected := `to consist of
-\s*<\[\]interface {} \| len:2, cap:2>: \[1, "C"\]
+\s*<\[\]interface {} \| len:2, cap:2>: \[<int>1, <string>"C"\]
 the missing elements were
 \s*<\[\]string \| len:1, cap:1>: \["C"\]
 the extra elements were
@@ -173,7 +173,7 @@ the extra elements were
 					Expect([]interface{}{1, "B"}).NotTo(ConsistOf(1, "B"))
 				})
 
-				expected := `not to consist of\n\s*<\[\]interface {} \| len:2, cap:2>: \[1, "B"\]`
+				expected := `not to consist of\n\s*<\[\]interface {} \| len:2, cap:2>: \[<int>1, <string>"B"\]`
 				Expect(failures).To(ConsistOf(MatchRegexp(expected)))
 			})
 		})

--- a/matchers/contain_elements_matcher_test.go
+++ b/matchers/contain_elements_matcher_test.go
@@ -133,7 +133,7 @@ the missing elements were
 				})
 
 				expected := `to contain elements
-\s*<\[\]interface {} \| len:2, cap:2>: \[1, "C"\]
+\s*<\[\]interface {} \| len:2, cap:2>: \[<int>1, <string>"C"\]
 the missing elements were
 \s*<\[\]string \| len:1, cap:1>: \["C"\]`
 				Expect(failures).To(ConsistOf(MatchRegexp(expected)))
@@ -144,7 +144,7 @@ the missing elements were
 					Expect([]interface{}{1, "B"}).NotTo(ContainElements(1, "B"))
 				})
 
-				expected := `not to contain elements\n\s*<\[\]interface {} \| len:2, cap:2>: \[1, "B"\]`
+				expected := `not to contain elements\n\s*<\[\]interface {} \| len:2, cap:2>: \[<int>1, <string>"B"\]`
 				Expect(failures).To(ConsistOf(MatchRegexp(expected)))
 			})
 		})


### PR DESCRIPTION
When a value is contained in an interface{} we should show the type of
the value as well as the interface{} type.

Consider the test:

  Expect([]interface{}{1}).To(Equal([]interface{}{uint(1)}))

Previous message:

  Expected
    <[]interface {} | len:1, cap:1>: [1]
  to equal
    <[]interface {} | len:1, cap:1>: [1]

New message:

  Expected
    <[]interface {} | len:1, cap:1>: [<int>1]
  to equal
    <[]interface {} | len:1, cap:1>: [<uint>1]

By showing the type, it's much easier to work out what is going on.

Fixes #161 
Fixes #385