### PR TITLE
Fix error message in BeNumericallyMatcher

### DIFF
--- a/matchers/be_numerically_matcher.go
+++ b/matchers/be_numerically_matcher.go
@@ -45,7 +45,7 @@ func (matcher *BeNumericallyMatcher) Match(actual interface{}) (success bool, er
 		return false, fmt.Errorf("Expected a number.  Got:\n%s", format.Object(matcher.CompareTo[0], 1))
 	}
 	if len(matcher.CompareTo) == 2 && !isNumber(matcher.CompareTo[1]) {
-		return false, fmt.Errorf("Expected a number.  Got:\n%s", format.Object(matcher.CompareTo[0], 1))
+		return false, fmt.Errorf("Expected a number.  Got:\n%s", format.Object(matcher.CompareTo[1], 1))
 	}
 
 	switch matcher.Comparator {

--- a/matchers/be_numerically_matcher_test.go
+++ b/matchers/be_numerically_matcher_test.go
@@ -143,6 +143,7 @@ var _ = Describe("BeNumerically", func() {
 			success, err = (&BeNumericallyMatcher{Comparator: "~", CompareTo: []interface{}{3.0, "foo"}}).Match(5.0)
 			Expect(success).Should(BeFalse())
 			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("foo"))
 
 			success, err = (&BeNumericallyMatcher{Comparator: "==", CompareTo: []interface{}{"bar"}}).Match(5)
 			Expect(success).Should(BeFalse())


### PR DESCRIPTION
When passing a non-number as the threshold, the error message should
contain the problematic threshold, not the expected value.