### PR TITLE
Set consistently and eventually defaults on init

### DIFF
--- a/env.go
+++ b/env.go
@@ -1,0 +1,40 @@
+package gomega
+
+import (
+	"os"
+
+	"github.com/onsi/gomega/internal/defaults"
+)
+
+const (
+	ConsistentlyDurationEnvVarName        = "GOMEGA_DEFAULT_CONSISTENTLY_DURATION"
+	ConsistentlyPollingIntervalEnvVarName = "GOMEGA_DEFAULT_CONSISTENTLY_POLLING_INTERVAL"
+	EventuallyTimeoutEnvVarName           = "GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT"
+	EventuallyPollingIntervalEnvVarName   = "GOMEGA_DEFAULT_EVENTUALLY_POLLING_INTERVAL"
+)
+
+func init() {
+	defaults.SetDurationFromEnv(
+		os.Getenv,
+		SetDefaultConsistentlyDuration,
+		ConsistentlyDurationEnvVarName,
+	)
+
+	defaults.SetDurationFromEnv(
+		os.Getenv,
+		SetDefaultConsistentlyPollingInterval,
+		ConsistentlyPollingIntervalEnvVarName,
+	)
+
+	defaults.SetDurationFromEnv(
+		os.Getenv,
+		SetDefaultEventuallyTimeout,
+		EventuallyTimeoutEnvVarName,
+	)
+
+	defaults.SetDurationFromEnv(
+		os.Getenv,
+		SetDefaultEventuallyPollingInterval,
+		EventuallyPollingIntervalEnvVarName,
+	)
+}

--- a/internal/defaults/defaults_suite_test.go
+++ b/internal/defaults/defaults_suite_test.go
@@ -1,0 +1,13 @@
+package defaults_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestDefaults(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gomega Defaults Suite")
+}

--- a/internal/defaults/env.go
+++ b/internal/defaults/env.go
@@ -1,0 +1,22 @@
+package defaults
+
+import (
+	"fmt"
+	"time"
+)
+
+func SetDurationFromEnv(getDurationFromEnv func(string) string, varSetter func(time.Duration), name string) {
+	durationFromEnv := getDurationFromEnv(name)
+
+	if len(durationFromEnv) == 0 {
+		return
+	}
+
+	duration, err := time.ParseDuration(durationFromEnv)
+
+	if err != nil {
+		panic(fmt.Sprintf("Expected a duration when using %s!  Parse error %v", name, err))
+	}
+
+	varSetter(duration)
+}

--- a/internal/defaults/env_test.go
+++ b/internal/defaults/env_test.go
@@ -1,0 +1,81 @@
+package defaults_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	d "github.com/onsi/gomega/internal/defaults"
+)
+
+var _ = Describe("Durations", func() {
+	var (
+		duration       *time.Duration
+		envVarGot      string
+		envVarToReturn string
+
+		getDurationFromEnv = func(name string) string {
+			envVarGot = name
+			return envVarToReturn
+		}
+
+		setDuration = func(t time.Duration) {
+			duration = &t
+		}
+
+		setDurationCalled = func() bool {
+			return duration != nil
+		}
+
+		resetDuration = func() {
+			duration = nil
+		}
+	)
+
+	BeforeEach(func() {
+		resetDuration()
+	})
+
+	Context("When the environment has a duration", func() {
+		Context("When the duration is valid", func() {
+			BeforeEach(func() {
+				envVarToReturn = "10m"
+
+				d.SetDurationFromEnv(getDurationFromEnv, setDuration, "MY_ENV_VAR")
+			})
+
+			It("sets the duration", func() {
+				Expect(envVarGot).To(Equal("MY_ENV_VAR"))
+				Expect(setDurationCalled()).To(Equal(true))
+				Expect(*duration).To(Equal(10 * time.Minute))
+			})
+		})
+
+		Context("When the duration is not valid", func() {
+			BeforeEach(func() {
+				envVarToReturn = "10"
+			})
+
+			It("panics with a helpful error message", func() {
+				Expect(func() {
+					d.SetDurationFromEnv(getDurationFromEnv, setDuration, "MY_ENV_VAR")
+				}).To(PanicWith(MatchRegexp("Expected a duration when using MY_ENV_VAR")))
+			})
+		})
+	})
+
+	Context("When the environment does not have a duration", func() {
+		BeforeEach(func() {
+			envVarToReturn = ""
+
+			d.SetDurationFromEnv(getDurationFromEnv, setDuration, "MY_ENV_VAR")
+		})
+
+		It("does not set the duration", func() {
+			Expect(envVarGot).To(Equal("MY_ENV_VAR"))
+			Expect(setDurationCalled()).To(Equal(false))
+			Expect(duration).To(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
Closes #434

What
----

Adds an `init` hook which calls a helper for each default we want to set

Adds environment variables:

* `GOMEGA_DEFAULT_CONSISTENTLY_DURATION`
* `GOMEGA_DEFAULT_CONSISTENTLY_POLLING_INTERVAL`
* `GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT`
* `GOMEGA_DEFAULT_EVENTUALLY_POLLING_INTERVAL`

Why
---


> As a Vito, I want to set the duration/timeout/poll interval for `Consistently` and `Eventually` without stressing about my CI system being under load

Closes #434

