### PR TITLE
gexec.Build should create a binary with an expected name

### DIFF
--- a/gexec/build.go
+++ b/gexec/build.go
@@ -3,8 +3,6 @@
 package gexec
 
 import (
-	"crypto/md5"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"go/build"
@@ -197,9 +195,7 @@ func newExecutablePath(gopath, packagePath string, suffixes ...string) (string, 
 		return "", errors.New("$GOPATH not provided when building " + packagePath)
 	}
 
-	hash := md5.Sum([]byte(packagePath))
-	filename := fmt.Sprintf("%s-%x%s", path.Base(packagePath), hex.EncodeToString(hash[:]), strings.Join(suffixes, ""))
-	executable := filepath.Join(tmpDir, filename)
+	executable := filepath.Join(tmpDir, path.Base(packagePath))
 
 	if runtime.GOOS == "windows" {
 		executable += ".exe"

--- a/gexec/build_test.go
+++ b/gexec/build_test.go
@@ -24,6 +24,7 @@ var _ = Describe(".Build", func() {
 			compiledPath, err := gexec.Build(packagePath)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(compiledPath).Should(BeAnExistingFile())
+			Expect(filepath.Base(compiledPath)).Should(MatchRegexp(`firefly(|.exe)$`))
 		})
 
 		Context("and CleanupBuildArtifacts has been called", func() {


### PR DESCRIPTION
Changes introduced in onsi/gomega#410 is breaking backward compatibility for building binaries with an expected name.