### PR TITLE
add caching for go modules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,12 @@ jobs:
       with:
         go-version: ${{ matrix.version }}
     - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
     - run: make test


### PR DESCRIPTION
When Github Actions run, it is downloading the go modules each run. It looks like some failures are happening because of rate limiting on some go modules.

This will use the `actions/cache` Github Action to cache the golang modules.