### PR TITLE
feat: HaveHTTPStatus multiple expected values

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -423,7 +423,8 @@ func BeADirectory() types.GomegaMatcher {
 //Expected must be either an int or a string.
 //  Expect(resp).Should(HaveHTTPStatus(http.StatusOK))   // asserts that resp.StatusCode == 200
 //  Expect(resp).Should(HaveHTTPStatus("404 Not Found")) // asserts that resp.Status == "404 Not Found"
-func HaveHTTPStatus(expected interface{}) types.GomegaMatcher {
+//  Expect(resp).Should(HaveHTTPStatus(http.StatusOK, http.StatusNoContent))   // asserts that resp.StatusCode == 200 || resp.StatusCode == 204
+func HaveHTTPStatus(expected ...interface{}) types.GomegaMatcher {
 	return &matchers.HaveHTTPStatusMatcher{Expected: expected}
 }
 

--- a/matchers/have_http_status_matcher_test.go
+++ b/matchers/have_http_status_matcher_test.go
@@ -11,31 +11,68 @@ import (
 )
 
 var _ = Describe("HaveHTTPStatus", func() {
-	When("ACTUAL is *http.Response", func() {
-		When("EXPECTED is integer", func() {
-			It("matches the StatusCode", func() {
+	When("EXPECTED is single integer", func() {
+		It("matches the StatusCode", func() {
+			resp := &http.Response{StatusCode: http.StatusOK}
+			Expect(resp).To(HaveHTTPStatus(http.StatusOK))
+			Expect(resp).NotTo(HaveHTTPStatus(http.StatusNotFound))
+		})
+	})
+
+	When("EXPECTED is single string", func() {
+		It("matches the Status", func() {
+			resp := &http.Response{Status: "200 OK"}
+			Expect(resp).To(HaveHTTPStatus("200 OK"))
+			Expect(resp).NotTo(HaveHTTPStatus("404 Not Found"))
+		})
+	})
+
+	When("EXPECTED is empty", func() {
+		It("errors", func() {
+			failures := InterceptGomegaFailures(func() {
 				resp := &http.Response{StatusCode: http.StatusOK}
-				Expect(resp).To(HaveHTTPStatus(http.StatusOK))
-				Expect(resp).NotTo(HaveHTTPStatus(http.StatusNotFound))
+				Expect(resp).To(HaveHTTPStatus())
 			})
+			Expect(failures).To(HaveLen(1))
+			Expect(failures[0]).To(Equal("HaveHTTPStatus matcher must be passed an int or a string. Got nothing"))
 		})
+	})
 
-		When("EXPECTED is string", func() {
-			It("matches the Status", func() {
-				resp := &http.Response{Status: "200 OK"}
-				Expect(resp).To(HaveHTTPStatus("200 OK"))
-				Expect(resp).NotTo(HaveHTTPStatus("404 Not Found"))
+	When("EXPECTED is not a string or integer", func() {
+		It("errors", func() {
+			failures := InterceptGomegaFailures(func() {
+				resp := &http.Response{StatusCode: http.StatusOK}
+				Expect(resp).To(HaveHTTPStatus(true))
 			})
+			Expect(failures).To(HaveLen(1))
+			Expect(failures[0]).To(Equal("HaveHTTPStatus matcher must be passed int or string types. Got:\n    <bool>: true"))
 		})
+	})
 
-		When("EXPECTED is anything else", func() {
-			It("does not match", func() {
-				failures := InterceptGomegaFailures(func() {
-					resp := &http.Response{StatusCode: http.StatusOK}
-					Expect(resp).NotTo(HaveHTTPStatus(true))
-				})
-				Expect(failures).To(ConsistOf("HaveHTTPStatus matcher must be passed an int or a string. Got:\n    <bool>: true"))
+	When("EXPECTED is a list of strings and integers", func() {
+		It("matches the StatusCode and Status", func() {
+			resp := &http.Response{
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+			}
+			Expect(resp).To(HaveHTTPStatus(http.StatusOK, http.StatusNoContent, http.StatusNotFound))
+			Expect(resp).To(HaveHTTPStatus("204 Feeling Fine", "200 OK", "404 Not Found"))
+			Expect(resp).To(HaveHTTPStatus("204 Feeling Fine", http.StatusOK, "404 Not Found"))
+			Expect(resp).To(HaveHTTPStatus(http.StatusNoContent, "200 OK", http.StatusNotFound))
+			Expect(resp).NotTo(HaveHTTPStatus(http.StatusNotFound, http.StatusNoContent, http.StatusGone))
+			Expect(resp).NotTo(HaveHTTPStatus("204 Feeling Fine", "201 Sleeping", "404 Not Found"))
+			Expect(resp).NotTo(HaveHTTPStatus(http.StatusNotFound, "404 Not Found", http.StatusGone))
+		})
+	})
+
+	When("EXPECTED is a list containing non-string or integer types", func() {
+		It("errors", func() {
+			failures := InterceptGomegaFailures(func() {
+				resp := &http.Response{StatusCode: http.StatusOK}
+				Expect(resp).To(HaveHTTPStatus(http.StatusGone, "204 No Content", true, http.StatusNotFound))
 			})
+			Expect(failures).To(HaveLen(1))
+			Expect(failures[0]).To(Equal("HaveHTTPStatus matcher must be passed int or string types. Got:\n    <bool>: true"))
 		})
 	})
 
@@ -62,7 +99,8 @@ var _ = Describe("HaveHTTPStatus", func() {
 					resp := &httptest.ResponseRecorder{Code: http.StatusOK}
 					Expect(resp).NotTo(HaveHTTPStatus(nil))
 				})
-				Expect(failures).To(ConsistOf("HaveHTTPStatus matcher must be passed an int or a string. Got:\n    <nil>: nil"))
+				Expect(failures).To(HaveLen(1))
+				Expect(failures[0]).To(Equal("HaveHTTPStatus matcher must be passed int or string types. Got:\n    <nil>: nil"))
 			})
 		})
 	})
@@ -72,12 +110,13 @@ var _ = Describe("HaveHTTPStatus", func() {
 			failures := InterceptGomegaFailures(func() {
 				Expect("foo").To(HaveHTTPStatus(http.StatusOK))
 			})
-			Expect(failures).To(ConsistOf("HaveHTTPStatus matcher expects *http.Response or *httptest.ResponseRecorder. Got:\n    <string>: foo"))
+			Expect(failures).To(HaveLen(1))
+			Expect(failures[0]).To(Equal("HaveHTTPStatus matcher expects *http.Response or *httptest.ResponseRecorder. Got:\n    <string>: foo"))
 		})
 	})
 
 	Describe("FailureMessage", func() {
-		It("returns message", func() {
+		It("returns a message for a single expected value", func() {
 			failures := InterceptGomegaFailures(func() {
 				resp := &http.Response{
 					StatusCode: http.StatusBadGateway,
@@ -96,10 +135,32 @@ var _ = Describe("HaveHTTPStatus", func() {
 to have HTTP status
     <int>: 200`), failures[0])
 		})
+
+		It("returns a message for a multiple expected values", func() {
+			failures := InterceptGomegaFailures(func() {
+				resp := &http.Response{
+					StatusCode: http.StatusBadGateway,
+					Status:     "502 Bad Gateway",
+					Body:       ioutil.NopCloser(strings.NewReader("did not like it")),
+				}
+				Expect(resp).To(HaveHTTPStatus(http.StatusOK, http.StatusNotFound, "204 No content"))
+			})
+			Expect(failures).To(HaveLen(1))
+			Expect(failures[0]).To(Equal(`Expected
+    <*http.Response>: {
+        Status:     <string>: "502 Bad Gateway"
+        StatusCode: <int>: 502
+        Body:       <string>: "did not like it"
+    }
+to have HTTP status
+    <int>: 200
+    <int>: 404
+    <string>: 204 No content`), failures[0])
+		})
 	})
 
 	Describe("NegatedFailureMessage", func() {
-		It("returns message", func() {
+		It("returns a message for a single expected value", func() {
 			failures := InterceptGomegaFailures(func() {
 				resp := &http.Response{
 					StatusCode: http.StatusOK,
@@ -117,6 +178,28 @@ to have HTTP status
     }
 not to have HTTP status
     <int>: 200`), failures[0])
+		})
+
+		It("returns a message for a multiple expected values", func() {
+			failures := InterceptGomegaFailures(func() {
+				resp := &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     "200 OK",
+					Body:       ioutil.NopCloser(strings.NewReader("got it!")),
+				}
+				Expect(resp).NotTo(HaveHTTPStatus(http.StatusOK, "204 No content", http.StatusGone))
+			})
+			Expect(failures).To(HaveLen(1))
+			Expect(failures[0]).To(Equal(`Expected
+    <*http.Response>: {
+        Status:     <string>: "200 OK"
+        StatusCode: <int>: 200
+        Body:       <string>: "got it!"
+    }
+not to have HTTP status
+    <int>: 200
+    <string>: 204 No content
+    <int>: 410`), failures[0])
 		})
 	})
 })


### PR DESCRIPTION
Note, this builds on #461, so that should be merged first.

Sometimes more than one HTTP status is acceptable. For example a server
may (correctly) return HTTP 204 for an empty response, or it might
return HTTP 200 for an empty response - and we might want to accept
either.

We can now write:
```go
Expect(resp).To(HaveHTTPStatus(http.StatusOK, http.StatusNoContent))
```
And it will match either. This is simpler than using Or() or
SatisfyAny().