### PR TITLE
chore: stop using deprecated ioutil package

### DIFF
--- a/gexec/build.go
+++ b/gexec/build.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -222,11 +221,11 @@ func temporaryDirectory() (string, error) {
 	mu.Lock()
 	defer mu.Unlock()
 	if tmpDir == "" {
-		tmpDir, err = ioutil.TempDir("", "gexec_artifacts")
+		tmpDir, err = os.MkdirTemp("", "gexec_artifacts")
 		if err != nil {
 			return "", err
 		}
 	}
 
-	return ioutil.TempDir(tmpDir, "g")
+	return os.MkdirTemp(tmpDir, "g")
 }

--- a/gexec/build_test.go
+++ b/gexec/build_test.go
@@ -2,7 +2,6 @@ package gexec_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -99,7 +98,7 @@ var _ = Describe(".BuildIn", func() {
 	BeforeEach(func() {
 		var err error
 		original = os.Getenv("GOPATH")
-		gopath, err = ioutil.TempDir("", "")
+		gopath, err = os.MkdirTemp("", "")
 		Expect(err).NotTo(HaveOccurred())
 		copyFile(filepath.Join("_fixture", "firefly", "main.go"), filepath.Join(gopath, "src", target), "main.go")
 		Expect(os.Setenv("GOPATH", filepath.Join(os.TempDir(), "emptyFakeGopath"))).To(Succeed())
@@ -235,7 +234,7 @@ var _ = Describe(".CompiledTestIn", func() {
 	BeforeEach(func() {
 		var err error
 		original = os.Getenv("GOPATH")
-		gopath, err = ioutil.TempDir("", "")
+		gopath, err = os.MkdirTemp("", "")
 		Expect(err).NotTo(HaveOccurred())
 		copyFile(filepath.Join("_fixture", "firefly", "main.go"), filepath.Join(gopath, "src", target), "main.go")
 		Expect(os.Setenv("GOPATH", filepath.Join(os.TempDir(), "emptyFakeGopath"))).To(Succeed())
@@ -278,7 +277,7 @@ var _ = Describe(".CompiledTestIn", func() {
 
 func copyFile(source, directory, basename string) {
 	Expect(os.MkdirAll(directory, 0755)).To(Succeed())
-	content, err := ioutil.ReadFile(source)
+	content, err := os.ReadFile(source)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(ioutil.WriteFile(filepath.Join(directory, basename), content, 0644)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(directory, basename), content, 0644)).To(Succeed())
 }

--- a/gexec/session_test.go
+++ b/gexec/session_test.go
@@ -4,7 +4,6 @@ package gexec_test
 
 import (
 	"io"
-	"io/ioutil"
 	"os/exec"
 	"syscall"
 	"time"
@@ -326,8 +325,8 @@ var _ = Describe("Session", func() {
 
 			When("discarding the output of the command", func() {
 				BeforeEach(func() {
-					outWriter = ioutil.Discard
-					errWriter = ioutil.Discard
+					outWriter = io.Discard
+					errWriter = io.Discard
 				})
 
 				It("executes succesfuly", func() {
@@ -387,8 +386,8 @@ var _ = Describe("Session", func() {
 
 			When("discarding the output of the command", func() {
 				BeforeEach(func() {
-					outWriter = ioutil.Discard
-					errWriter = ioutil.Discard
+					outWriter = io.Discard
+					errWriter = io.Discard
 				})
 
 				It("executes succesfuly", func() {

--- a/ghttp/handlers.go
+++ b/ghttp/handlers.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -117,7 +117,7 @@ func (g GHTTPWithGomega) VerifyHeaderKV(key string, values ...string) http.Handl
 func (g GHTTPWithGomega) VerifyBody(expectedBody []byte) http.HandlerFunc {
 	return CombineHandlers(
 		func(w http.ResponseWriter, req *http.Request) {
-			body, err := ioutil.ReadAll(req.Body)
+			body, err := io.ReadAll(req.Body)
 			req.Body.Close()
 			g.gomega.Expect(err).ShouldNot(HaveOccurred())
 			g.gomega.Expect(body).Should(Equal(expectedBody), "Body Mismatch")
@@ -133,7 +133,7 @@ func (g GHTTPWithGomega) VerifyJSON(expectedJSON string) http.HandlerFunc {
 	return CombineHandlers(
 		g.VerifyMimeType("application/json"),
 		func(w http.ResponseWriter, req *http.Request) {
-			body, err := ioutil.ReadAll(req.Body)
+			body, err := io.ReadAll(req.Body)
 			req.Body.Close()
 			g.gomega.Expect(err).ShouldNot(HaveOccurred())
 			g.gomega.Expect(body).Should(MatchJSON(expectedJSON), "JSON Mismatch")
@@ -182,7 +182,7 @@ func (g GHTTPWithGomega) VerifyProtoRepresenting(expected proto.Message) http.Ha
 	return CombineHandlers(
 		g.VerifyContentType("application/x-protobuf"),
 		func(w http.ResponseWriter, req *http.Request) {
-			body, err := ioutil.ReadAll(req.Body)
+			body, err := io.ReadAll(req.Body)
 			g.gomega.Expect(err).ShouldNot(HaveOccurred())
 			req.Body.Close()
 

--- a/ghttp/test_server.go
+++ b/ghttp/test_server.go
@@ -111,7 +111,6 @@ package ghttp
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -269,7 +268,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	} else {
 		s.rwMutex.Unlock()
 		if s.GetAllowUnhandledRequests() {
-			ioutil.ReadAll(req.Body)
+			io.ReadAll(req.Body)
 			req.Body.Close()
 			w.WriteHeader(s.GetUnhandledRequestStatusCode())
 		} else {

--- a/ghttp/test_server_test.go
+++ b/ghttp/test_server_test.go
@@ -3,7 +3,6 @@ package ghttp_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -60,7 +59,7 @@ var _ = Describe("TestServer", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(resp.StatusCode).Should(Equal(200))
 
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			resp.Body.Close()
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -70,7 +69,7 @@ var _ = Describe("TestServer", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(resp.StatusCode).Should(Equal(200))
 
-			body2, err := ioutil.ReadAll(resp.Body)
+			body2, err := io.ReadAll(resp.Body)
 			resp.Body.Close()
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -102,7 +101,7 @@ var _ = Describe("TestServer", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(resp.StatusCode).Should(Equal(http.StatusForbidden))
 
-				data, err := ioutil.ReadAll(resp.Body)
+				data, err := io.ReadAll(resp.Body)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(data).Should(BeEmpty())
 			})
@@ -792,7 +791,7 @@ var _ = Describe("TestServer", func() {
 
 					Expect(resp.StatusCode).Should(Equal(http.StatusCreated))
 
-					body, err := ioutil.ReadAll(resp.Body)
+					body, err := io.ReadAll(resp.Body)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(body).Should(Equal([]byte("sweet")))
 
@@ -801,7 +800,7 @@ var _ = Describe("TestServer", func() {
 
 					Expect(resp.StatusCode).Should(Equal(http.StatusOK))
 
-					body, err = ioutil.ReadAll(resp.Body)
+					body, err = io.ReadAll(resp.Body)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(body).Should(Equal([]byte("sour")))
 				})
@@ -820,7 +819,7 @@ var _ = Describe("TestServer", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 
 					Expect(resp.StatusCode).Should(Equal(http.StatusCreated))
-					Expect(ioutil.ReadAll(resp.Body)).Should(Equal([]byte("sweet")))
+					Expect(io.ReadAll(resp.Body)).Should(Equal([]byte("sweet")))
 					Expect(resp.Header.Get("X-Custom-Header")).Should(Equal("my header"))
 				})
 			})
@@ -854,7 +853,7 @@ var _ = Describe("TestServer", func() {
 
 				Expect(resp.StatusCode).Should(Equal(http.StatusCreated))
 
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(body).Should(Equal([]byte("tasty")))
 
@@ -863,7 +862,7 @@ var _ = Describe("TestServer", func() {
 
 				Expect(resp.StatusCode).Should(Equal(http.StatusCreated))
 
-				body, err = ioutil.ReadAll(resp.Body)
+				body, err = io.ReadAll(resp.Body)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(body).Should(Equal([]byte("treat")))
 			})
@@ -881,7 +880,7 @@ var _ = Describe("TestServer", func() {
 
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(resp.StatusCode).Should(Equal(http.StatusOK))
-					body, err := ioutil.ReadAll(resp.Body)
+					body, err := io.ReadAll(resp.Body)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(body).Should(BeEmpty())
 
@@ -905,7 +904,7 @@ var _ = Describe("TestServer", func() {
 
 					Expect(resp.StatusCode).Should(Equal(http.StatusCreated))
 
-					body, err := ioutil.ReadAll(resp.Body)
+					body, err := io.ReadAll(resp.Body)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(body).Should(MatchJSON("[1,2,3]"))
 				})
@@ -990,7 +989,7 @@ var _ = Describe("TestServer", func() {
 
 					Expect(resp.StatusCode).Should(Equal(http.StatusCreated))
 
-					body, err := ioutil.ReadAll(resp.Body)
+					body, err := io.ReadAll(resp.Body)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(body).Should(MatchJSON(`{"Key": "Jim", "Value": "Codes"}`))
 				})
@@ -1071,7 +1070,7 @@ var _ = Describe("TestServer", func() {
 					Expect(resp.StatusCode).Should(Equal(http.StatusCreated))
 
 					var received protobuf.SimpleMessage
-					body, err := ioutil.ReadAll(resp.Body)
+					body, err := io.ReadAll(resp.Body)
 					Expect(err).ShouldNot(HaveOccurred())
 					err = proto.Unmarshal(body, &received)
 					Expect(err).ShouldNot(HaveOccurred())

--- a/gmeasure/cache.go
+++ b/gmeasure/cache.go
@@ -4,7 +4,6 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -66,16 +65,16 @@ func (cache ExperimentCache) readHeader(filename string) (CachedExperimentHeader
 List returns a list of all Cached Experiments found in the cache.
 */
 func (cache ExperimentCache) List() ([]CachedExperimentHeader, error) {
-	out := []CachedExperimentHeader{}
-	infos, err := ioutil.ReadDir(cache.Path)
+	var out []CachedExperimentHeader
+	entries, err := os.ReadDir(cache.Path)
 	if err != nil {
 		return out, err
 	}
-	for _, info := range infos {
-		if filepath.Ext(info.Name()) != CACHE_EXT {
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) != CACHE_EXT {
 			continue
 		}
-		header, err := cache.readHeader(info.Name())
+		header, err := cache.readHeader(entry.Name())
 		if err != nil {
 			return out, err
 		}
@@ -88,15 +87,15 @@ func (cache ExperimentCache) List() ([]CachedExperimentHeader, error) {
 Clear empties out the cache - this will delete any and all detected cache files in the cache directory.  Use with caution!
 */
 func (cache ExperimentCache) Clear() error {
-	infos, err := ioutil.ReadDir(cache.Path)
+	entries, err := os.ReadDir(cache.Path)
 	if err != nil {
 		return err
 	}
-	for _, info := range infos {
-		if filepath.Ext(info.Name()) != CACHE_EXT {
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) != CACHE_EXT {
 			continue
 		}
-		err := os.Remove(filepath.Join(cache.Path, info.Name()))
+		err := os.Remove(filepath.Join(cache.Path, entry.Name()))
 		if err != nil {
 			return err
 		}

--- a/matchers/be_a_directory_test.go
+++ b/matchers/be_a_directory_test.go
@@ -1,7 +1,6 @@
 package matchers_test
 
 import (
-	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -14,12 +13,12 @@ var _ = Describe("BeADirectoryMatcher", func() {
 		It("should do the right thing", func() {
 			Expect("/dne/test").ShouldNot(BeADirectory())
 
-			tmpFile, err := ioutil.TempFile("", "gomega-test-tempfile")
+			tmpFile, err := os.CreateTemp("", "gomega-test-tempfile")
 			Expect(err).ShouldNot(HaveOccurred())
 			defer os.Remove(tmpFile.Name())
 			Expect(tmpFile.Name()).ShouldNot(BeADirectory())
 
-			tmpDir, err := ioutil.TempDir("", "gomega-test-tempdir")
+			tmpDir, err := os.MkdirTemp("", "gomega-test-tempdir")
 			Expect(err).ShouldNot(HaveOccurred())
 			defer os.Remove(tmpDir)
 			Expect(tmpDir).Should(BeADirectory())

--- a/matchers/be_a_regular_file_test.go
+++ b/matchers/be_a_regular_file_test.go
@@ -1,7 +1,6 @@
 package matchers_test
 
 import (
-	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -14,12 +13,12 @@ var _ = Describe("BeARegularFileMatcher", func() {
 		It("should do the right thing", func() {
 			Expect("/dne/test").ShouldNot(BeARegularFile())
 
-			tmpFile, err := ioutil.TempFile("", "gomega-test-tempfile")
+			tmpFile, err := os.CreateTemp("", "gomega-test-tempfile")
 			Expect(err).ShouldNot(HaveOccurred())
 			defer os.Remove(tmpFile.Name())
 			Expect(tmpFile.Name()).Should(BeARegularFile())
 
-			tmpDir, err := ioutil.TempDir("", "gomega-test-tempdir")
+			tmpDir, err := os.MkdirTemp("", "gomega-test-tempdir")
 			Expect(err).ShouldNot(HaveOccurred())
 			defer os.Remove(tmpDir)
 			Expect(tmpDir).ShouldNot(BeARegularFile())

--- a/matchers/be_an_existing_file_test.go
+++ b/matchers/be_an_existing_file_test.go
@@ -1,7 +1,6 @@
 package matchers_test
 
 import (
-	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -14,12 +13,12 @@ var _ = Describe("BeAnExistingFileMatcher", func() {
 		It("should do the right thing", func() {
 			Expect("/dne/test").ShouldNot(BeAnExistingFile())
 
-			tmpFile, err := ioutil.TempFile("", "gomega-test-tempfile")
+			tmpFile, err := os.CreateTemp("", "gomega-test-tempfile")
 			Expect(err).ShouldNot(HaveOccurred())
 			defer os.Remove(tmpFile.Name())
 			Expect(tmpFile.Name()).Should(BeAnExistingFile())
 
-			tmpDir, err := ioutil.TempDir("", "gomega-test-tempdir")
+			tmpDir, err := os.MkdirTemp("", "gomega-test-tempdir")
 			Expect(err).ShouldNot(HaveOccurred())
 			defer os.Remove(tmpDir)
 			Expect(tmpDir).Should(BeAnExistingFile())

--- a/matchers/have_http_body_matcher.go
+++ b/matchers/have_http_body_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 
@@ -81,7 +81,7 @@ func (matcher *HaveHTTPBodyMatcher) body(actual interface{}) ([]byte, error) {
 		if a.Body != nil {
 			defer a.Body.Close()
 			var err error
-			matcher.cachedBody, err = ioutil.ReadAll(a.Body)
+			matcher.cachedBody, err = io.ReadAll(a.Body)
 			if err != nil {
 				return nil, fmt.Errorf("error reading response body: %w", err)
 			}

--- a/matchers/have_http_body_matcher_test.go
+++ b/matchers/have_http_body_matcher_test.go
@@ -2,7 +2,7 @@ package matchers_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,13 +15,13 @@ var _ = Describe("HaveHTTPBody", func() {
 	When("ACTUAL is *http.Response", func() {
 		It("matches the body", func() {
 			const body = "this is the body"
-			resp := &http.Response{Body: ioutil.NopCloser(strings.NewReader(body))}
+			resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
 			Expect(resp).To(HaveHTTPBody(body))
 		})
 
 		It("mismatches the body", func() {
 			const body = "this is the body"
-			resp := &http.Response{Body: ioutil.NopCloser(strings.NewReader(body))}
+			resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
 			Expect(resp).NotTo(HaveHTTPBody("something else"))
 		})
 	})
@@ -52,25 +52,25 @@ var _ = Describe("HaveHTTPBody", func() {
 	When("EXPECTED is []byte", func() {
 		It("matches the body", func() {
 			const body = "this is the body"
-			resp := &http.Response{Body: ioutil.NopCloser(strings.NewReader(body))}
+			resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
 			Expect(resp).To(HaveHTTPBody([]byte(body)))
 		})
 
 		It("mismatches the body", func() {
 			const body = "this is the body"
-			resp := &http.Response{Body: ioutil.NopCloser(strings.NewReader(body))}
+			resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
 			Expect(resp).NotTo(HaveHTTPBody([]byte("something else")))
 		})
 	})
 
 	When("EXPECTED is a submatcher", func() {
 		It("matches the body", func() {
-			resp := &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"some":"json"}`))}
+			resp := &http.Response{Body: io.NopCloser(strings.NewReader(`{"some":"json"}`))}
 			Expect(resp).To(HaveHTTPBody(MatchJSON(`{ "some": "json" }`)))
 		})
 
 		It("mismatches the body", func() {
-			resp := &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"some":"json"}`))}
+			resp := &http.Response{Body: io.NopCloser(strings.NewReader(`{"some":"json"}`))}
 			Expect(resp).NotTo(HaveHTTPBody(MatchJSON(`{ "something": "different" }`)))
 		})
 	})
@@ -78,7 +78,7 @@ var _ = Describe("HaveHTTPBody", func() {
 	When("EXPECTED is something else", func() {
 		It("errors", func() {
 			failures := InterceptGomegaFailures(func() {
-				resp := &http.Response{Body: ioutil.NopCloser(strings.NewReader("body"))}
+				resp := &http.Response{Body: io.NopCloser(strings.NewReader("body"))}
 				Expect(resp).To(HaveHTTPBody(map[int]bool{}))
 			})
 			Expect(failures).To(HaveLen(1))
@@ -90,7 +90,7 @@ var _ = Describe("HaveHTTPBody", func() {
 		Context("EXPECTED is string", func() {
 			It("returns a match failure message", func() {
 				failures := InterceptGomegaFailures(func() {
-					resp := &http.Response{Body: ioutil.NopCloser(strings.NewReader("this is the body"))}
+					resp := &http.Response{Body: io.NopCloser(strings.NewReader("this is the body"))}
 					Expect(resp).To(HaveHTTPBody("this is a different body"))
 				})
 				Expect(failures).To(HaveLen(1))
@@ -104,7 +104,7 @@ to equal
 		Context("EXPECTED is []byte", func() {
 			It("returns a match failure message", func() {
 				failures := InterceptGomegaFailures(func() {
-					resp := &http.Response{Body: ioutil.NopCloser(strings.NewReader("this is the body"))}
+					resp := &http.Response{Body: io.NopCloser(strings.NewReader("this is the body"))}
 					Expect(resp).To(HaveHTTPBody([]byte("this is a different body")))
 				})
 				Expect(failures).To(HaveLen(1))
@@ -118,7 +118,7 @@ to equal
 		Context("EXPECTED is submatcher", func() {
 			It("returns a match failure message", func() {
 				failures := InterceptGomegaFailures(func() {
-					resp := &http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"some":"json"}`))}
+					resp := &http.Response{Body: io.NopCloser(strings.NewReader(`{"some":"json"}`))}
 					Expect(resp).To(HaveHTTPBody(MatchJSON(`{"other":"stuff"}`)))
 				})
 				Expect(failures).To(HaveLen(1))
@@ -139,7 +139,7 @@ to match JSON of
 			It("returns a negated failure message", func() {
 				const body = "this is the body"
 				failures := InterceptGomegaFailures(func() {
-					resp := &http.Response{Body: ioutil.NopCloser(strings.NewReader(body))}
+					resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
 					Expect(resp).NotTo(HaveHTTPBody(body))
 				})
 				Expect(failures).To(HaveLen(1))
@@ -154,7 +154,7 @@ not to equal
 			It("returns a match failure message", func() {
 				const body = "this is the body"
 				failures := InterceptGomegaFailures(func() {
-					resp := &http.Response{Body: ioutil.NopCloser(strings.NewReader(body))}
+					resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
 					Expect(resp).NotTo(HaveHTTPBody([]byte(body)))
 				})
 				Expect(failures).To(HaveLen(1))
@@ -169,7 +169,7 @@ not to equal
 			It("returns a match failure message", func() {
 				const body = `{"some":"json"}`
 				failures := InterceptGomegaFailures(func() {
-					resp := &http.Response{Body: ioutil.NopCloser(strings.NewReader(body))}
+					resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
 					Expect(resp).NotTo(HaveHTTPBody(MatchJSON(body)))
 				})
 				Expect(failures).To(HaveLen(1))

--- a/matchers/have_http_status_matcher.go
+++ b/matchers/have_http_status_matcher.go
@@ -2,7 +2,7 @@ package matchers
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -78,7 +78,7 @@ func formatHttpResponse(input interface{}) string {
 	body := "<nil>"
 	if resp.Body != nil {
 		defer resp.Body.Close()
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			data = []byte("<error reading body>")
 		}

--- a/matchers/have_http_status_matcher_test.go
+++ b/matchers/have_http_status_matcher_test.go
@@ -1,7 +1,7 @@
 package matchers_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -121,7 +121,7 @@ var _ = Describe("HaveHTTPStatus", func() {
 				resp := &http.Response{
 					StatusCode: http.StatusBadGateway,
 					Status:     "502 Bad Gateway",
-					Body:       ioutil.NopCloser(strings.NewReader("did not like it")),
+					Body:       io.NopCloser(strings.NewReader("did not like it")),
 				}
 				Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 			})
@@ -141,7 +141,7 @@ to have HTTP status
 				resp := &http.Response{
 					StatusCode: http.StatusBadGateway,
 					Status:     "502 Bad Gateway",
-					Body:       ioutil.NopCloser(strings.NewReader("did not like it")),
+					Body:       io.NopCloser(strings.NewReader("did not like it")),
 				}
 				Expect(resp).To(HaveHTTPStatus(http.StatusOK, http.StatusNotFound, "204 No content"))
 			})
@@ -165,7 +165,7 @@ to have HTTP status
 				resp := &http.Response{
 					StatusCode: http.StatusOK,
 					Status:     "200 OK",
-					Body:       ioutil.NopCloser(strings.NewReader("got it!")),
+					Body:       io.NopCloser(strings.NewReader("got it!")),
 				}
 				Expect(resp).NotTo(HaveHTTPStatus(http.StatusOK))
 			})
@@ -185,7 +185,7 @@ not to have HTTP status
 				resp := &http.Response{
 					StatusCode: http.StatusOK,
 					Status:     "200 OK",
-					Body:       ioutil.NopCloser(strings.NewReader("got it!")),
+					Body:       io.NopCloser(strings.NewReader("got it!")),
 				}
 				Expect(resp).NotTo(HaveHTTPStatus(http.StatusOK, "204 No content", http.StatusGone))
 			})

--- a/matchers/matcher_tests_suite_test.go
+++ b/matchers/matcher_tests_suite_test.go
@@ -2,7 +2,7 @@ package matchers_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -34,7 +34,7 @@ func Test(t *testing.T) {
 
 func readFileContents(filePath string) []byte {
 	f := openFile(filePath)
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		panic(fmt.Errorf("failed to read file contents: %v", err))
 	}


### PR DESCRIPTION
This package was deprecated in Go 1.16. This chore breaks compatability
with Go 1.15 which is out of support.