### PR TITLE
fix transformation error reporting

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -492,7 +492,7 @@ func Not(matcher types.GomegaMatcher) types.GomegaMatcher {
 //  Expect(1).To(WithTransform(plus1, Equal(2))
 //
 //   var failingplus1 = func(i int) (int, error) { return 42, "this does not compute" }
-//   Expect(1).To(WithTrafo(failingplus1, Equal(2)))
+//   Expect(1).To(WithTransform(failingplus1, Equal(2)))
 //
 //And(), Or(), Not() and WithTransform() allow matchers to be composed into complex expressions.
 func WithTransform(transform interface{}, matcher types.GomegaMatcher) types.GomegaMatcher {

--- a/matchers/with_transform.go
+++ b/matchers/with_transform.go
@@ -64,7 +64,7 @@ func (m *WithTransformMatcher) Match(actual interface{}) (bool, error) {
 	result := fn.Call([]reflect.Value{param})
 	if len(result) == 2 {
 		if !result[1].IsNil() {
-			return false, fmt.Errorf("Transform function failed: %e", result[1].Interface())
+			return false, fmt.Errorf("Transform function failed: %s", result[1].Interface().(error).Error())
 		}
 	}
 	m.transformedValue = result[0].Interface() // expect exactly one value

--- a/matchers/with_transform_test.go
+++ b/matchers/with_transform_test.go
@@ -132,7 +132,7 @@ var _ = Describe("WithTransformMatcher", func() {
 				success, err := WithTransform(trafo, Equal(actual)).Match(actual)
 				Expect(success).To(BeFalse())
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("that does not transform"))
+				Expect(err.Error()).To(MatchRegexp(": that does not transform$"))
 			})
 		})
 


### PR DESCRIPTION
* fix transformation error reporting using an invalid %e formatting direction.
* updates corresponding unit test to catch such formatting directive errors.
* corrects documentation to correctly refer to `WithTransformation`.