### PR TITLE
Add HaveValue matcher

### DIFF
--- a/matchers/have_value.go
+++ b/matchers/have_value.go
@@ -66,7 +66,7 @@ func (m *HaveValueMatcher) Match(actual interface{}) (bool, error) {
 }
 
 func (m *HaveValueMatcher) FailureMessage(_ interface{}) (message string) {
-	return m.Matcher.NegatedFailureMessage(m.resolvedActual)
+	return m.Matcher.FailureMessage(m.resolvedActual)
 }
 
 func (m *HaveValueMatcher) NegatedFailureMessage(_ interface{}) (message string) {

--- a/matchers/have_value.go
+++ b/matchers/have_value.go
@@ -1,0 +1,71 @@
+package matchers
+
+import (
+	"reflect"
+
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+)
+
+// HavePoint applies the given matcher to the resulting value after optionally
+// resolving actual to the value it points to or its interface value, repeatedly
+// as necessary. It fails if a pointer or interface is nil. In contrast to
+// gstruct.PointTo, HaveValue does not expect actual to be a pointer but instead
+// also accepts non-pointer and interface values.
+//
+//   actual := 42
+//   Expect(actual).To(HaveValue(42))
+//   Expect(&actual).To(HaveValue(42))
+func HaveValue(matcher types.GomegaMatcher) types.GomegaMatcher {
+	return &HaveValueMatcher{
+		Matcher: matcher,
+	}
+}
+
+type HaveValueMatcher struct {
+	Matcher types.GomegaMatcher // given matcher to apply to resolved value.
+	failure string              // failure message, if any.
+}
+
+func (m *HaveValueMatcher) Match(actual interface{}) (bool, error) {
+	val := reflect.ValueOf(actual)
+	for allowedIndirs := 32; allowedIndirs > 0; allowedIndirs-- {
+		// return an error if value isn't valid.
+		if !val.IsValid() {
+			m.failure = format.Message(
+				actual, "not to be <nil>")
+			return false, nil
+		}
+		switch val.Kind() {
+		case reflect.Ptr, reflect.Interface:
+			// resolve pointers and interfaces to their values, then rinse and
+			// repeat.
+			if val.IsNil() {
+				m.failure = format.Message(
+					actual, "not to be <nil>")
+				return false, nil
+			}
+			val = val.Elem()
+			continue
+		default:
+			// forward the final value to the specified matcher.
+			elem := val.Interface()
+			match, err := m.Matcher.Match(elem)
+			if !match {
+				m.failure = m.Matcher.FailureMessage(elem)
+			}
+			return match, err
+		}
+	}
+	// too many indirections: extreme star gazing, indeed...?
+	m.failure = format.Message(actual, "indirecting too many times")
+	return false, nil
+}
+
+func (m *HaveValueMatcher) FailureMessage(_ interface{}) (message string) {
+	return m.failure
+}
+
+func (m *HaveValueMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return m.Matcher.NegatedFailureMessage(actual)
+}

--- a/matchers/have_value_test.go
+++ b/matchers/have_value_test.go
@@ -32,6 +32,13 @@ var _ = Describe("HaveValue", func() {
 		Expect(m.Match(&p)).Error().To(MatchError(MatchRegexp("not to be <nil>$")))
 	})
 
+	It("should use the matcher's failure message", func() {
+		m := HaveValue(Equal(42))
+		Expect(m.Match(666)).To(BeFalse())
+		Expect(m.FailureMessage(nil)).To(Equal("Expected\n    <int>: 666\nto equal\n    <int>: 42"))
+		Expect(m.NegatedFailureMessage(nil)).To(Equal("Expected\n    <int>: 666\nnot to equal\n    <int>: 42"))
+	})
+
 	It("should unwrap the value pointed to, even repeatedly", func() {
 		i := 1
 		Expect(&i).To(HaveValue(Equal(1)))

--- a/matchers/have_value_test.go
+++ b/matchers/have_value_test.go
@@ -1,0 +1,51 @@
+package matchers_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/matchers"
+)
+
+type I interface {
+	M()
+}
+
+type S struct {
+	V int
+}
+
+func (s S) M() {}
+
+var _ = Describe("HaveValue", func() {
+
+	It("should fail when passed nil", func() {
+		var p *struct{}
+		m := HaveValue(BeNil())
+		Expect(m.Match(p)).To(BeFalse())
+		Expect(m.FailureMessage(p)).To(MatchRegexp("not to be <nil>$"))
+	})
+
+	It("should fail when passed nil indirectly", func() {
+		var p *struct{}
+		m := HaveValue(BeNil())
+		Expect(m.Match(&p)).To(BeFalse())
+		Expect(m.FailureMessage(&p)).To(MatchRegexp("not to be <nil>$"))
+	})
+
+	It("should unwrap the value pointed to", func() {
+		i := 1
+		Expect(&i).To(HaveValue(Equal(1)))
+		Expect(&i).NotTo(HaveValue(Equal(2)))
+
+		p := &i
+		Expect(&p).To(HaveValue(Equal(1)))
+		Expect(&p).NotTo(HaveValue(Equal(2)))
+	})
+
+	It("should unwrap the value inside an interface", func() {
+		var i I = &S{V: 42}
+		Expect(i).To(HaveValue(Equal(S{V: 42})))
+		Expect(i).NotTo(HaveValue(Equal(S{})))
+	})
+
+})

--- a/matchers/have_value_test.go
+++ b/matchers/have_value_test.go
@@ -32,17 +32,20 @@ var _ = Describe("HaveValue", func() {
 		Expect(m.FailureMessage(&p)).To(MatchRegexp("not to be <nil>$"))
 	})
 
-	It("should unwrap the value pointed to", func() {
+	It("should unwrap the value pointed to, even repeatedly", func() {
 		i := 1
 		Expect(&i).To(HaveValue(Equal(1)))
 		Expect(&i).NotTo(HaveValue(Equal(2)))
 
-		p := &i
-		Expect(&p).To(HaveValue(Equal(1)))
-		Expect(&p).NotTo(HaveValue(Equal(2)))
+		pi := &i
+		Expect(pi).To(HaveValue(Equal(1)))
+		Expect(pi).NotTo(HaveValue(Equal(2)))
+
+		Expect(&pi).To(HaveValue(Equal(1)))
+		Expect(&pi).NotTo(HaveValue(Equal(2)))
 	})
 
-	It("should unwrap the value inside an interface", func() {
+	It("should unwrap the value of an interface", func() {
 		var i I = &S{V: 42}
 		Expect(i).To(HaveValue(Equal(S{V: 42})))
 		Expect(i).NotTo(HaveValue(Equal(S{})))


### PR DESCRIPTION
- adds `HaveValue` matcher (as discussed in #484) that optionally dereferences pointers and interfaces into values, even repeatedly, as needed.
- adds tests for `HaveValue` matcher.
