### PR TITLE
chore: fix description of HaveField matcher

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -357,12 +357,12 @@ func HaveKeyWithValue(key interface{}, value interface{}) types.GomegaMatcher {
 //    type Person struct {
 //        FirstName string
 //        LastName string
-//		  DOB time.Time
+//        DOB time.Time
 //    }
 //    Expect(book).To(HaveField("Title", "Les Miserables"))
 //    Expect(book).To(HaveField("Title", ContainSubstring("Les"))
-//    Expect(book).To(HaveField("Person.FirstName", Equal("Victor"))
-//    Expect(book).To(HaveField("Person.DOB.Year()", BeNumerically("<", 1900))
+//    Expect(book).To(HaveField("Author.FirstName", Equal("Victor"))
+//    Expect(book).To(HaveField("Author.DOB.Year()", BeNumerically("<", 1900))
 func HaveField(field string, expected interface{}) types.GomegaMatcher {
 	return &matchers.HaveFieldMatcher{
 		Field:    field,


### PR DESCRIPTION
While checking the [changelog of v1.17.0](https://github.com/onsi/gomega/releases/tag/v1.17.0), I noticed the code example given in the comment alongside the  `HaveField` matcher source was erroneous.

This is a small fix to patch the comment.

Thanks.