### PR TITLE
fix: use ioutil for Go 1.15 and lower

### DIFF
--- a/gexec/build.go
+++ b/gexec/build.go
@@ -13,6 +13,8 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+
+	"github.com/onsi/gomega/internal/gutil"
 )
 
 var (
@@ -221,11 +223,11 @@ func temporaryDirectory() (string, error) {
 	mu.Lock()
 	defer mu.Unlock()
 	if tmpDir == "" {
-		tmpDir, err = os.MkdirTemp("", "gexec_artifacts")
+		tmpDir, err = gutil.MkdirTemp("", "gexec_artifacts")
 		if err != nil {
 			return "", err
 		}
 	}
 
-	return os.MkdirTemp(tmpDir, "g")
+	return gutil.MkdirTemp(tmpDir, "g")
 }

--- a/gexec/build_test.go
+++ b/gexec/build_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/internal/gutil"
 )
 
 var packagePath = "./_fixture/firefly"
@@ -98,7 +99,7 @@ var _ = Describe(".BuildIn", func() {
 	BeforeEach(func() {
 		var err error
 		original = os.Getenv("GOPATH")
-		gopath, err = os.MkdirTemp("", "")
+		gopath, err = gutil.MkdirTemp("", "")
 		Expect(err).NotTo(HaveOccurred())
 		copyFile(filepath.Join("_fixture", "firefly", "main.go"), filepath.Join(gopath, "src", target), "main.go")
 		Expect(os.Setenv("GOPATH", filepath.Join(os.TempDir(), "emptyFakeGopath"))).To(Succeed())
@@ -234,7 +235,7 @@ var _ = Describe(".CompiledTestIn", func() {
 	BeforeEach(func() {
 		var err error
 		original = os.Getenv("GOPATH")
-		gopath, err = os.MkdirTemp("", "")
+		gopath, err = gutil.MkdirTemp("", "")
 		Expect(err).NotTo(HaveOccurred())
 		copyFile(filepath.Join("_fixture", "firefly", "main.go"), filepath.Join(gopath, "src", target), "main.go")
 		Expect(os.Setenv("GOPATH", filepath.Join(os.TempDir(), "emptyFakeGopath"))).To(Succeed())
@@ -277,7 +278,7 @@ var _ = Describe(".CompiledTestIn", func() {
 
 func copyFile(source, directory, basename string) {
 	Expect(os.MkdirAll(directory, 0755)).To(Succeed())
-	content, err := os.ReadFile(source)
+	content, err := gutil.ReadFile(source)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(os.WriteFile(filepath.Join(directory, basename), content, 0644)).To(Succeed())
+	Expect(gutil.WriteFile(filepath.Join(directory, basename), content)).To(Succeed())
 }

--- a/ghttp/handlers.go
+++ b/ghttp/handlers.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -15,6 +14,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/internal/gutil"
 	"github.com/onsi/gomega/types"
 )
 
@@ -117,7 +117,7 @@ func (g GHTTPWithGomega) VerifyHeaderKV(key string, values ...string) http.Handl
 func (g GHTTPWithGomega) VerifyBody(expectedBody []byte) http.HandlerFunc {
 	return CombineHandlers(
 		func(w http.ResponseWriter, req *http.Request) {
-			body, err := io.ReadAll(req.Body)
+			body, err := gutil.ReadAll(req.Body)
 			req.Body.Close()
 			g.gomega.Expect(err).ShouldNot(HaveOccurred())
 			g.gomega.Expect(body).Should(Equal(expectedBody), "Body Mismatch")
@@ -133,7 +133,7 @@ func (g GHTTPWithGomega) VerifyJSON(expectedJSON string) http.HandlerFunc {
 	return CombineHandlers(
 		g.VerifyMimeType("application/json"),
 		func(w http.ResponseWriter, req *http.Request) {
-			body, err := io.ReadAll(req.Body)
+			body, err := gutil.ReadAll(req.Body)
 			req.Body.Close()
 			g.gomega.Expect(err).ShouldNot(HaveOccurred())
 			g.gomega.Expect(body).Should(MatchJSON(expectedJSON), "JSON Mismatch")
@@ -182,7 +182,7 @@ func (g GHTTPWithGomega) VerifyProtoRepresenting(expected proto.Message) http.Ha
 	return CombineHandlers(
 		g.VerifyContentType("application/x-protobuf"),
 		func(w http.ResponseWriter, req *http.Request) {
-			body, err := io.ReadAll(req.Body)
+			body, err := gutil.ReadAll(req.Body)
 			g.gomega.Expect(err).ShouldNot(HaveOccurred())
 			req.Body.Close()
 

--- a/ghttp/test_server.go
+++ b/ghttp/test_server.go
@@ -120,6 +120,7 @@ import (
 	"sync"
 
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/internal/gutil"
 )
 
 func new() *Server {
@@ -268,7 +269,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	} else {
 		s.rwMutex.Unlock()
 		if s.GetAllowUnhandledRequests() {
-			io.ReadAll(req.Body)
+			gutil.ReadAll(req.Body)
 			req.Body.Close()
 			w.WriteHeader(s.GetUnhandledRequestStatusCode())
 		} else {

--- a/ghttp/test_server_test.go
+++ b/ghttp/test_server_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/ghttp/protobuf"
+	"github.com/onsi/gomega/internal/gutil"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -59,7 +60,7 @@ var _ = Describe("TestServer", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(resp.StatusCode).Should(Equal(200))
 
-			body, err := io.ReadAll(resp.Body)
+			body, err := gutil.ReadAll(resp.Body)
 			resp.Body.Close()
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -69,7 +70,7 @@ var _ = Describe("TestServer", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(resp.StatusCode).Should(Equal(200))
 
-			body2, err := io.ReadAll(resp.Body)
+			body2, err := gutil.ReadAll(resp.Body)
 			resp.Body.Close()
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -101,7 +102,7 @@ var _ = Describe("TestServer", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(resp.StatusCode).Should(Equal(http.StatusForbidden))
 
-				data, err := io.ReadAll(resp.Body)
+				data, err := gutil.ReadAll(resp.Body)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(data).Should(BeEmpty())
 			})
@@ -791,7 +792,7 @@ var _ = Describe("TestServer", func() {
 
 					Expect(resp.StatusCode).Should(Equal(http.StatusCreated))
 
-					body, err := io.ReadAll(resp.Body)
+					body, err := gutil.ReadAll(resp.Body)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(body).Should(Equal([]byte("sweet")))
 
@@ -800,7 +801,7 @@ var _ = Describe("TestServer", func() {
 
 					Expect(resp.StatusCode).Should(Equal(http.StatusOK))
 
-					body, err = io.ReadAll(resp.Body)
+					body, err = gutil.ReadAll(resp.Body)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(body).Should(Equal([]byte("sour")))
 				})
@@ -819,7 +820,7 @@ var _ = Describe("TestServer", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 
 					Expect(resp.StatusCode).Should(Equal(http.StatusCreated))
-					Expect(io.ReadAll(resp.Body)).Should(Equal([]byte("sweet")))
+					Expect(gutil.ReadAll(resp.Body)).Should(Equal([]byte("sweet")))
 					Expect(resp.Header.Get("X-Custom-Header")).Should(Equal("my header"))
 				})
 			})
@@ -853,7 +854,7 @@ var _ = Describe("TestServer", func() {
 
 				Expect(resp.StatusCode).Should(Equal(http.StatusCreated))
 
-				body, err := io.ReadAll(resp.Body)
+				body, err := gutil.ReadAll(resp.Body)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(body).Should(Equal([]byte("tasty")))
 
@@ -862,7 +863,7 @@ var _ = Describe("TestServer", func() {
 
 				Expect(resp.StatusCode).Should(Equal(http.StatusCreated))
 
-				body, err = io.ReadAll(resp.Body)
+				body, err = gutil.ReadAll(resp.Body)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(body).Should(Equal([]byte("treat")))
 			})
@@ -880,7 +881,7 @@ var _ = Describe("TestServer", func() {
 
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(resp.StatusCode).Should(Equal(http.StatusOK))
-					body, err := io.ReadAll(resp.Body)
+					body, err := gutil.ReadAll(resp.Body)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(body).Should(BeEmpty())
 
@@ -904,7 +905,7 @@ var _ = Describe("TestServer", func() {
 
 					Expect(resp.StatusCode).Should(Equal(http.StatusCreated))
 
-					body, err := io.ReadAll(resp.Body)
+					body, err := gutil.ReadAll(resp.Body)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(body).Should(MatchJSON("[1,2,3]"))
 				})
@@ -989,7 +990,7 @@ var _ = Describe("TestServer", func() {
 
 					Expect(resp.StatusCode).Should(Equal(http.StatusCreated))
 
-					body, err := io.ReadAll(resp.Body)
+					body, err := gutil.ReadAll(resp.Body)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(body).Should(MatchJSON(`{"Key": "Jim", "Value": "Codes"}`))
 				})
@@ -1070,7 +1071,7 @@ var _ = Describe("TestServer", func() {
 					Expect(resp.StatusCode).Should(Equal(http.StatusCreated))
 
 					var received protobuf.SimpleMessage
-					body, err := io.ReadAll(resp.Body)
+					body, err := gutil.ReadAll(resp.Body)
 					Expect(err).ShouldNot(HaveOccurred())
 					err = proto.Unmarshal(body, &received)
 					Expect(err).ShouldNot(HaveOccurred())

--- a/gmeasure/cache.go
+++ b/gmeasure/cache.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/onsi/gomega/internal/gutil"
 )
 
 const CACHE_EXT = ".gmeasure-cache"
@@ -66,15 +68,15 @@ List returns a list of all Cached Experiments found in the cache.
 */
 func (cache ExperimentCache) List() ([]CachedExperimentHeader, error) {
 	var out []CachedExperimentHeader
-	entries, err := os.ReadDir(cache.Path)
+	names, err := gutil.ReadDir(cache.Path)
 	if err != nil {
 		return out, err
 	}
-	for _, entry := range entries {
-		if filepath.Ext(entry.Name()) != CACHE_EXT {
+	for _, name := range names {
+		if filepath.Ext(name) != CACHE_EXT {
 			continue
 		}
-		header, err := cache.readHeader(entry.Name())
+		header, err := cache.readHeader(name)
 		if err != nil {
 			return out, err
 		}
@@ -87,15 +89,15 @@ func (cache ExperimentCache) List() ([]CachedExperimentHeader, error) {
 Clear empties out the cache - this will delete any and all detected cache files in the cache directory.  Use with caution!
 */
 func (cache ExperimentCache) Clear() error {
-	entries, err := os.ReadDir(cache.Path)
+	names, err := gutil.ReadDir(cache.Path)
 	if err != nil {
 		return err
 	}
-	for _, entry := range entries {
-		if filepath.Ext(entry.Name()) != CACHE_EXT {
+	for _, name := range names {
+		if filepath.Ext(name) != CACHE_EXT {
 			continue
 		}
-		err := os.Remove(filepath.Join(cache.Path, entry.Name()))
+		err := os.Remove(filepath.Join(cache.Path, name))
 		if err != nil {
 			return err
 		}

--- a/internal/gutil/post_ioutil.go
+++ b/internal/gutil/post_ioutil.go
@@ -1,0 +1,48 @@
+//go:build go1.16
+// +build go1.16
+
+// Package gutil is a replacement for ioutil, which should not be used in new
+// code as of Go 1.16. With Go 1.16 and higher, this implementation
+// uses the ioutil replacement functions in "io" and "os" with some
+// Gomega specifics. This means that we should not get deprecation warnings
+// for ioutil when they are added.
+package gutil
+
+import (
+	"io"
+	"os"
+)
+
+func NopCloser(r io.Reader) io.ReadCloser {
+	return io.NopCloser(r)
+}
+
+func ReadAll(r io.Reader) ([]byte, error) {
+	return io.ReadAll(r)
+}
+
+func ReadDir(dirname string) ([]string, error) {
+	entries, err := os.ReadDir(dirname)
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+
+	return names, nil
+}
+
+func ReadFile(filename string) ([]byte, error) {
+	return os.ReadFile(filename)
+}
+
+func MkdirTemp(dir, pattern string) (string, error) {
+	return os.MkdirTemp(dir, pattern)
+}
+
+func WriteFile(filename string, data []byte) error {
+	return os.WriteFile(filename, data, 0644)
+}

--- a/internal/gutil/using_ioutil.go
+++ b/internal/gutil/using_ioutil.go
@@ -1,0 +1,47 @@
+//go:build !go1.16
+// +build !go1.16
+
+// Package gutil is a replacement for ioutil, which should not be used in new
+// code as of Go 1.16. With Go 1.15 and lower, this implementation
+// uses the ioutil functions, meaning that although Gomega is not officially
+// supported on these versions, it is still likely to work.
+package gutil
+
+import (
+	"io"
+	"io/ioutil"
+)
+
+func NopCloser(r io.Reader) io.ReadCloser {
+	return ioutil.NopCloser(r)
+}
+
+func ReadAll(r io.Reader) ([]byte, error) {
+	return ioutil.ReadAll(r)
+}
+
+func ReadDir(dirname string) ([]string, error) {
+	files, err := ioutil.ReadDir(dirname)
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for _, file := range files {
+		names = append(names, file.Name())
+	}
+
+	return names, nil
+}
+
+func ReadFile(filename string) ([]byte, error) {
+	return ioutil.ReadFile(filename)
+}
+
+func MkdirTemp(dir, pattern string) (string, error) {
+	return ioutil.TempDir(dir, pattern)
+}
+
+func WriteFile(filename string, data []byte) error {
+	return ioutil.WriteFile(filename, data, 0644)
+}

--- a/matchers/be_a_directory_test.go
+++ b/matchers/be_a_directory_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/internal/gutil"
 	. "github.com/onsi/gomega/matchers"
 )
 
@@ -18,7 +19,7 @@ var _ = Describe("BeADirectoryMatcher", func() {
 			defer os.Remove(tmpFile.Name())
 			Expect(tmpFile.Name()).ShouldNot(BeADirectory())
 
-			tmpDir, err := os.MkdirTemp("", "gomega-test-tempdir")
+			tmpDir, err := gutil.MkdirTemp("", "gomega-test-tempdir")
 			Expect(err).ShouldNot(HaveOccurred())
 			defer os.Remove(tmpDir)
 			Expect(tmpDir).Should(BeADirectory())

--- a/matchers/be_a_regular_file_test.go
+++ b/matchers/be_a_regular_file_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/internal/gutil"
 	. "github.com/onsi/gomega/matchers"
 )
 
@@ -18,7 +19,7 @@ var _ = Describe("BeARegularFileMatcher", func() {
 			defer os.Remove(tmpFile.Name())
 			Expect(tmpFile.Name()).Should(BeARegularFile())
 
-			tmpDir, err := os.MkdirTemp("", "gomega-test-tempdir")
+			tmpDir, err := gutil.MkdirTemp("", "gomega-test-tempdir")
 			Expect(err).ShouldNot(HaveOccurred())
 			defer os.Remove(tmpDir)
 			Expect(tmpDir).ShouldNot(BeARegularFile())

--- a/matchers/be_an_existing_file_test.go
+++ b/matchers/be_an_existing_file_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/internal/gutil"
 	. "github.com/onsi/gomega/matchers"
 )
 
@@ -18,7 +19,7 @@ var _ = Describe("BeAnExistingFileMatcher", func() {
 			defer os.Remove(tmpFile.Name())
 			Expect(tmpFile.Name()).Should(BeAnExistingFile())
 
-			tmpDir, err := os.MkdirTemp("", "gomega-test-tempdir")
+			tmpDir, err := gutil.MkdirTemp("", "gomega-test-tempdir")
 			Expect(err).ShouldNot(HaveOccurred())
 			defer os.Remove(tmpDir)
 			Expect(tmpDir).Should(BeAnExistingFile())

--- a/matchers/have_http_body_matcher.go
+++ b/matchers/have_http_body_matcher.go
@@ -2,11 +2,11 @@ package matchers
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 
 	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/internal/gutil"
 	"github.com/onsi/gomega/types"
 )
 
@@ -81,7 +81,7 @@ func (matcher *HaveHTTPBodyMatcher) body(actual interface{}) ([]byte, error) {
 		if a.Body != nil {
 			defer a.Body.Close()
 			var err error
-			matcher.cachedBody, err = io.ReadAll(a.Body)
+			matcher.cachedBody, err = gutil.ReadAll(a.Body)
 			if err != nil {
 				return nil, fmt.Errorf("error reading response body: %w", err)
 			}

--- a/matchers/have_http_body_matcher_test.go
+++ b/matchers/have_http_body_matcher_test.go
@@ -2,26 +2,26 @@ package matchers_test
 
 import (
 	"bytes"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/internal/gutil"
 )
 
 var _ = Describe("HaveHTTPBody", func() {
 	When("ACTUAL is *http.Response", func() {
 		It("matches the body", func() {
 			const body = "this is the body"
-			resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
+			resp := &http.Response{Body: gutil.NopCloser(strings.NewReader(body))}
 			Expect(resp).To(HaveHTTPBody(body))
 		})
 
 		It("mismatches the body", func() {
 			const body = "this is the body"
-			resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
+			resp := &http.Response{Body: gutil.NopCloser(strings.NewReader(body))}
 			Expect(resp).NotTo(HaveHTTPBody("something else"))
 		})
 	})
@@ -52,25 +52,25 @@ var _ = Describe("HaveHTTPBody", func() {
 	When("EXPECTED is []byte", func() {
 		It("matches the body", func() {
 			const body = "this is the body"
-			resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
+			resp := &http.Response{Body: gutil.NopCloser(strings.NewReader(body))}
 			Expect(resp).To(HaveHTTPBody([]byte(body)))
 		})
 
 		It("mismatches the body", func() {
 			const body = "this is the body"
-			resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
+			resp := &http.Response{Body: gutil.NopCloser(strings.NewReader(body))}
 			Expect(resp).NotTo(HaveHTTPBody([]byte("something else")))
 		})
 	})
 
 	When("EXPECTED is a submatcher", func() {
 		It("matches the body", func() {
-			resp := &http.Response{Body: io.NopCloser(strings.NewReader(`{"some":"json"}`))}
+			resp := &http.Response{Body: gutil.NopCloser(strings.NewReader(`{"some":"json"}`))}
 			Expect(resp).To(HaveHTTPBody(MatchJSON(`{ "some": "json" }`)))
 		})
 
 		It("mismatches the body", func() {
-			resp := &http.Response{Body: io.NopCloser(strings.NewReader(`{"some":"json"}`))}
+			resp := &http.Response{Body: gutil.NopCloser(strings.NewReader(`{"some":"json"}`))}
 			Expect(resp).NotTo(HaveHTTPBody(MatchJSON(`{ "something": "different" }`)))
 		})
 	})
@@ -78,7 +78,7 @@ var _ = Describe("HaveHTTPBody", func() {
 	When("EXPECTED is something else", func() {
 		It("errors", func() {
 			failures := InterceptGomegaFailures(func() {
-				resp := &http.Response{Body: io.NopCloser(strings.NewReader("body"))}
+				resp := &http.Response{Body: gutil.NopCloser(strings.NewReader("body"))}
 				Expect(resp).To(HaveHTTPBody(map[int]bool{}))
 			})
 			Expect(failures).To(HaveLen(1))
@@ -90,7 +90,7 @@ var _ = Describe("HaveHTTPBody", func() {
 		Context("EXPECTED is string", func() {
 			It("returns a match failure message", func() {
 				failures := InterceptGomegaFailures(func() {
-					resp := &http.Response{Body: io.NopCloser(strings.NewReader("this is the body"))}
+					resp := &http.Response{Body: gutil.NopCloser(strings.NewReader("this is the body"))}
 					Expect(resp).To(HaveHTTPBody("this is a different body"))
 				})
 				Expect(failures).To(HaveLen(1))
@@ -104,7 +104,7 @@ to equal
 		Context("EXPECTED is []byte", func() {
 			It("returns a match failure message", func() {
 				failures := InterceptGomegaFailures(func() {
-					resp := &http.Response{Body: io.NopCloser(strings.NewReader("this is the body"))}
+					resp := &http.Response{Body: gutil.NopCloser(strings.NewReader("this is the body"))}
 					Expect(resp).To(HaveHTTPBody([]byte("this is a different body")))
 				})
 				Expect(failures).To(HaveLen(1))
@@ -118,7 +118,7 @@ to equal
 		Context("EXPECTED is submatcher", func() {
 			It("returns a match failure message", func() {
 				failures := InterceptGomegaFailures(func() {
-					resp := &http.Response{Body: io.NopCloser(strings.NewReader(`{"some":"json"}`))}
+					resp := &http.Response{Body: gutil.NopCloser(strings.NewReader(`{"some":"json"}`))}
 					Expect(resp).To(HaveHTTPBody(MatchJSON(`{"other":"stuff"}`)))
 				})
 				Expect(failures).To(HaveLen(1))
@@ -139,7 +139,7 @@ to match JSON of
 			It("returns a negated failure message", func() {
 				const body = "this is the body"
 				failures := InterceptGomegaFailures(func() {
-					resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
+					resp := &http.Response{Body: gutil.NopCloser(strings.NewReader(body))}
 					Expect(resp).NotTo(HaveHTTPBody(body))
 				})
 				Expect(failures).To(HaveLen(1))
@@ -154,7 +154,7 @@ not to equal
 			It("returns a match failure message", func() {
 				const body = "this is the body"
 				failures := InterceptGomegaFailures(func() {
-					resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
+					resp := &http.Response{Body: gutil.NopCloser(strings.NewReader(body))}
 					Expect(resp).NotTo(HaveHTTPBody([]byte(body)))
 				})
 				Expect(failures).To(HaveLen(1))
@@ -169,7 +169,7 @@ not to equal
 			It("returns a match failure message", func() {
 				const body = `{"some":"json"}`
 				failures := InterceptGomegaFailures(func() {
-					resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
+					resp := &http.Response{Body: gutil.NopCloser(strings.NewReader(body))}
 					Expect(resp).NotTo(HaveHTTPBody(MatchJSON(body)))
 				})
 				Expect(failures).To(HaveLen(1))

--- a/matchers/have_http_status_matcher.go
+++ b/matchers/have_http_status_matcher.go
@@ -2,13 +2,13 @@ package matchers
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
 
 	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/internal/gutil"
 )
 
 type HaveHTTPStatusMatcher struct {
@@ -78,7 +78,7 @@ func formatHttpResponse(input interface{}) string {
 	body := "<nil>"
 	if resp.Body != nil {
 		defer resp.Body.Close()
-		data, err := io.ReadAll(resp.Body)
+		data, err := gutil.ReadAll(resp.Body)
 		if err != nil {
 			data = []byte("<error reading body>")
 		}

--- a/matchers/have_http_status_matcher_test.go
+++ b/matchers/have_http_status_matcher_test.go
@@ -1,13 +1,13 @@
 package matchers_test
 
 import (
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/internal/gutil"
 )
 
 var _ = Describe("HaveHTTPStatus", func() {
@@ -121,7 +121,7 @@ var _ = Describe("HaveHTTPStatus", func() {
 				resp := &http.Response{
 					StatusCode: http.StatusBadGateway,
 					Status:     "502 Bad Gateway",
-					Body:       io.NopCloser(strings.NewReader("did not like it")),
+					Body:       gutil.NopCloser(strings.NewReader("did not like it")),
 				}
 				Expect(resp).To(HaveHTTPStatus(http.StatusOK))
 			})
@@ -141,7 +141,7 @@ to have HTTP status
 				resp := &http.Response{
 					StatusCode: http.StatusBadGateway,
 					Status:     "502 Bad Gateway",
-					Body:       io.NopCloser(strings.NewReader("did not like it")),
+					Body:       gutil.NopCloser(strings.NewReader("did not like it")),
 				}
 				Expect(resp).To(HaveHTTPStatus(http.StatusOK, http.StatusNotFound, "204 No content"))
 			})
@@ -165,7 +165,7 @@ to have HTTP status
 				resp := &http.Response{
 					StatusCode: http.StatusOK,
 					Status:     "200 OK",
-					Body:       io.NopCloser(strings.NewReader("got it!")),
+					Body:       gutil.NopCloser(strings.NewReader("got it!")),
 				}
 				Expect(resp).NotTo(HaveHTTPStatus(http.StatusOK))
 			})
@@ -185,7 +185,7 @@ not to have HTTP status
 				resp := &http.Response{
 					StatusCode: http.StatusOK,
 					Status:     "200 OK",
-					Body:       io.NopCloser(strings.NewReader("got it!")),
+					Body:       gutil.NopCloser(strings.NewReader("got it!")),
 				}
 				Expect(resp).NotTo(HaveHTTPStatus(http.StatusOK, "204 No content", http.StatusGone))
 			})

--- a/matchers/matcher_tests_suite_test.go
+++ b/matchers/matcher_tests_suite_test.go
@@ -2,12 +2,12 @@ package matchers_test
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/internal/gutil"
 )
 
 type myStringer struct {
@@ -34,7 +34,7 @@ func Test(t *testing.T) {
 
 func readFileContents(filePath string) []byte {
 	f := openFile(filePath)
-	b, err := io.ReadAll(f)
+	b, err := gutil.ReadAll(f)
 	if err != nil {
 		panic(fmt.Errorf("failed to read file contents: %v", err))
 	}


### PR DESCRIPTION
Since Go 1.16 it has been recommended to no longer use ioutil in new
code. We want Gomega to look modern so we removed references to ioutil,
which also removes the chance of outdated code being copied. However we
got feedback that some users were stuck on Go 1.15 and lower and were
broken by this change. We have therefore introduces a "gutil" package
that implements similar functions to ioutil and redirect to the right
functions appropriate to the version of Go. This will hopefully:
- make it look intentional that ioutil is still used (rather than
looking like an omission)
- reduce the chance of ioutil usage being propagated by copying
- limit the possibility of deprecation warnings