### PR TITLE
add pointer support to HaveField matcher

### DIFF
--- a/matchers/have_field.go
+++ b/matchers/have_field.go
@@ -12,6 +12,13 @@ func extractField(actual interface{}, field string) (interface{}, error) {
 	fields := strings.SplitN(field, ".", 2)
 	actualValue := reflect.ValueOf(actual)
 
+	if actualValue.Kind() == reflect.Ptr {
+		actualValue = actualValue.Elem()
+	}
+	if actualValue == (reflect.Value{}) {
+		return nil, fmt.Errorf("HaveField encountered nil while dereferencing a pointer of type %T.", actual)
+	}
+
 	if actualValue.Kind() != reflect.Struct {
 		return nil, fmt.Errorf("HaveField encountered:\n%s\nWhich is not a struct.", format.Object(actual, 1))
 	}


### PR DESCRIPTION
This adds very basic pointer support to the recently added HaveField matcher.

I'm opening this before any feedback on the issue because I did some brief experiments to see how it could be implemented before we opened the issue. The approach might be a little to basic though.

resolves #494