### PR TITLE
Remove dependency on ginkgo v1.16.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.17'
+        go-version: '1.18'
     - uses: actions/checkout@v3
     - run: go mod tidy && git diff --exit-code go.mod go.sum
   build:

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,16 @@
 module github.com/onsi/gomega
 
-go 1.16
+go 1.18
 
 require (
 	github.com/golang/protobuf v1.5.2
 	github.com/onsi/ginkgo/v2 v2.0.0
 	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781
-	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	golang.org/x/text v0.3.6 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -28,7 +28,6 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo/v2 v2.0.0 h1:CcuG/HvWNkkaqCUpJifQY8z7qEMBJya6aLPx6ftGyjQ=
 github.com/onsi/ginkgo/v2 v2.0.0/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=


### PR DESCRIPTION
According to the go.sum, gomega depends on `github.com/onsi/ginkgo@v1.16.4` and yet it uses `github.com/onsi/ginkgo@v2.0.0`.

This is trivial to fix now that [Go 1.18 has shipped](https://github.com/golang/go/issues/44435), involving only changing the value of the Go directive to `1.18` and then doing a go mod tidy will remove it.

Resolves #529 