### PR TITLE
Fix for Go 1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,18 +3,26 @@ name: test
 on: [push, pull_request]
 
 jobs:
+  mod:
+    runs-on: ubuntu-latest
+    name: Check modules
+    steps:
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.17'
+    - uses: actions/checkout@v3
+    - run: go mod tidy && git diff --exit-code go.mod go.sum
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ '1.16', '1.17' ]
+        version: [ '1.17', '1.18' ]
     name: Go ${{ matrix.version }}
     steps:
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.version }}
-    - uses: actions/checkout@v2
-    - run: go mod tidy && git diff --exit-code go.mod go.sum
+    - uses: actions/checkout@v3
     - run: go vet ./...
     - run: mv ./tools ./tools.go
     - run: go get github.com/onsi/ginkgo/v2/ginkgo

--- a/gexec/build.go
+++ b/gexec/build.go
@@ -83,11 +83,11 @@ func CompileTest(packagePath string, args ...string) (compiledPath string, err e
 GetAndCompileTest is identical to CompileTest but `go get` the package before compiling tests.
 */
 func GetAndCompileTest(packagePath string, args ...string) (compiledPath string, err error) {
-	if err := getForTest(build.Default.GOPATH, packagePath, nil); err != nil {
+	if err := getForTest(build.Default.GOPATH, packagePath, []string{"GO111MODULE=off"}); err != nil {
 		return "", err
 	}
 
-	return doCompileTest(build.Default.GOPATH, packagePath, nil, args...)
+	return doCompileTest(build.Default.GOPATH, packagePath, []string{"GO111MODULE=off"}, args...)
 }
 
 /*
@@ -101,11 +101,11 @@ func CompileTestWithEnvironment(packagePath string, env []string, args ...string
 GetAndCompileTestWithEnvironment is identical to GetAndCompileTest but allows you to specify env vars to be set at build time.
 */
 func GetAndCompileTestWithEnvironment(packagePath string, env []string, args ...string) (compiledPath string, err error) {
-	if err := getForTest(build.Default.GOPATH, packagePath, env); err != nil {
+	if err := getForTest(build.Default.GOPATH, packagePath, append(env, "GO111MODULE=off")); err != nil {
 		return "", err
 	}
 
-	return doCompileTest(build.Default.GOPATH, packagePath, env, args...)
+	return doCompileTest(build.Default.GOPATH, packagePath, append(env, "GO111MODULE=off"), args...)
 }
 
 /*
@@ -119,11 +119,11 @@ func CompileTestIn(gopath string, packagePath string, args ...string) (compiledP
 GetAndCompileTestIn is identical to GetAndCompileTest but allows you to specify a custom $GOPATH (the first argument).
 */
 func GetAndCompileTestIn(gopath string, packagePath string, args ...string) (compiledPath string, err error) {
-	if err := getForTest(gopath, packagePath, nil); err != nil {
+	if err := getForTest(gopath, packagePath, []string{"GO111MODULE=off"}); err != nil {
 		return "", err
 	}
 
-	return doCompileTest(gopath, packagePath, nil, args...)
+	return doCompileTest(gopath, packagePath, []string{"GO111MODULE=off"}, args...)
 }
 
 func isLocalPackage(packagePath string) bool {

--- a/gexec/build_test.go
+++ b/gexec/build_test.go
@@ -132,7 +132,7 @@ var _ = Describe(".BuildIn", func() {
 
 var _ = Describe(".CompileTest", func() {
 	Context("a remote package", func() {
-		const remotePackage = "github.com/onsi/ginkgo/v2/types"
+		const remotePackage = "github.com/onsi/ginkgo/types"
 
 		It("compiles the specified test package", func() {
 			compiledPath, err := gexec.GetAndCompileTest(remotePackage)
@@ -200,7 +200,7 @@ var _ = Describe(".CompileTestWithEnvironment", func() {
 	}
 
 	Context("a remote package", func() {
-		const remotePackage = "github.com/onsi/ginkgo/v2/types"
+		const remotePackage = "github.com/onsi/ginkgo/types"
 
 		It("compiles the specified test package with the specified env vars", func() {
 			compiledPath, err := gexec.GetAndCompileTestWithEnvironment(remotePackage, env)
@@ -223,9 +223,7 @@ var _ = Describe(".CompileTestWithEnvironment", func() {
 })
 
 var _ = Describe(".CompiledTestIn", func() {
-	const (
-		target = "github.com/onsi/gomega/gexec/_fixture/firefly"
-	)
+	const target = "github.com/onsi/gomega/gexec/_fixture/firefly"
 
 	var (
 		original string
@@ -237,7 +235,6 @@ var _ = Describe(".CompiledTestIn", func() {
 		original = os.Getenv("GOPATH")
 		gopath, err = gutil.MkdirTemp("", "")
 		Expect(err).NotTo(HaveOccurred())
-		copyFile(filepath.Join("_fixture", "firefly", "main.go"), filepath.Join(gopath, "src", target), "main.go")
 		Expect(os.Setenv("GOPATH", filepath.Join(os.TempDir(), "emptyFakeGopath"))).To(Succeed())
 		Expect(os.Environ()).To(ContainElement(fmt.Sprintf("GOPATH=%s", filepath.Join(os.TempDir(), "emptyFakeGopath"))))
 	})
@@ -254,7 +251,7 @@ var _ = Describe(".CompiledTestIn", func() {
 	})
 
 	Context("a remote package", func() {
-		const remotePackage = "github.com/onsi/ginkgo/v2/types"
+		const remotePackage = "github.com/onsi/ginkgo/types"
 
 		It("compiles the specified test package", func() {
 			compiledPath, err := gexec.GetAndCompileTestIn(gopath, remotePackage)


### PR DESCRIPTION
This PR fixes gomega for Go 1.18 and drops support for Go 1.16 (end of lifed).

Change summary:

1. Stop testing on 1.16
2. Test on 1.18
3. Only check modules are tidy on current version in go.mod (different versions tidy differently).
4. Fix failing tests
5. Force `GO11MODULE=off` for functions that compile test binaries

Fixes #531 