### PR TITLE
fix: pass cmp.Options to cmp.Diff in BeComparableToMatcher

### DIFF
--- a/matchers/be_comparable_to_matcher.go
+++ b/matchers/be_comparable_to_matcher.go
@@ -3,6 +3,7 @@ package matchers
 import (
 	"bytes"
 	"fmt"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega/format"
 )
@@ -40,7 +41,7 @@ func (matcher *BeComparableToMatcher) Match(actual interface{}) (success bool, m
 }
 
 func (matcher *BeComparableToMatcher) FailureMessage(actual interface{}) (message string) {
-	return cmp.Diff(matcher.Expected, actual)
+	return cmp.Diff(matcher.Expected, actual, matcher.Options)
 }
 
 func (matcher *BeComparableToMatcher) NegatedFailureMessage(actual interface{}) (message string) {

--- a/matchers/be_comparable_to_matcher_test.go
+++ b/matchers/be_comparable_to_matcher_test.go
@@ -2,9 +2,10 @@ package matchers_test
 
 import (
 	"errors"
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -102,29 +103,54 @@ var _ = Describe("BeComparableTo", func() {
 	})
 
 	Context("When asserting equal between objects", func() {
-		It("should do the right thing", func() {
-			Expect(5).Should(BeComparableTo(5))
-			Expect(5.0).Should(BeComparableTo(5.0))
+		Context("with no additional cmp.Options", func() {
+			It("should do the right thing", func() {
+				Expect(5).Should(BeComparableTo(5))
+				Expect(5.0).Should(BeComparableTo(5.0))
 
-			Expect(5).ShouldNot(BeComparableTo("5"))
-			Expect(5).ShouldNot(BeComparableTo(5.0))
-			Expect(5).ShouldNot(BeComparableTo(3))
+				Expect(5).ShouldNot(BeComparableTo("5"))
+				Expect(5).ShouldNot(BeComparableTo(5.0))
+				Expect(5).ShouldNot(BeComparableTo(3))
 
-			Expect("5").Should(BeComparableTo("5"))
-			Expect([]int{1, 2}).Should(BeComparableTo([]int{1, 2}))
-			Expect([]int{1, 2}).ShouldNot(BeComparableTo([]int{2, 1}))
-			Expect([]byte{'f', 'o', 'o'}).Should(BeComparableTo([]byte{'f', 'o', 'o'}))
-			Expect([]byte{'f', 'o', 'o'}).ShouldNot(BeComparableTo([]byte{'b', 'a', 'r'}))
-			Expect(map[string]string{"a": "b", "c": "d"}).Should(BeComparableTo(map[string]string{"a": "b", "c": "d"}))
-			Expect(map[string]string{"a": "b", "c": "d"}).ShouldNot(BeComparableTo(map[string]string{"a": "b", "c": "e"}))
+				Expect("5").Should(BeComparableTo("5"))
+				Expect([]int{1, 2}).Should(BeComparableTo([]int{1, 2}))
+				Expect([]int{1, 2}).ShouldNot(BeComparableTo([]int{2, 1}))
+				Expect([]byte{'f', 'o', 'o'}).Should(BeComparableTo([]byte{'f', 'o', 'o'}))
+				Expect([]byte{'f', 'o', 'o'}).ShouldNot(BeComparableTo([]byte{'b', 'a', 'r'}))
+				Expect(map[string]string{"a": "b", "c": "d"}).Should(BeComparableTo(map[string]string{"a": "b", "c": "d"}))
+				Expect(map[string]string{"a": "b", "c": "d"}).ShouldNot(BeComparableTo(map[string]string{"a": "b", "c": "e"}))
+			})
+		})
 
-			Expect(myCustomType{s: "abc", n: 3, f: 2.0, arr: []string{"a", "b"}}).Should(BeComparableTo(myCustomType{s: "foo", n: 3, f: 2.0, arr: []string{"a", "b"}}, cmpopts.IgnoreUnexported(myCustomType{})))
+		Context("with custom cmp.Options", func() {
+			It("should do the right thing", func() {
+				Expect(myCustomType{s: "abc", n: 3, f: 2.0, arr: []string{"a", "b"}}).Should(BeComparableTo(myCustomType{s: "foo", n: 3, f: 2.0, arr: []string{"a", "b"}}, cmpopts.IgnoreUnexported(myCustomType{})))
 
-			Expect(myCustomType{s: "foo", n: 3, f: 2.0, arr: []string{"a", "b"}}).Should(BeComparableTo(myCustomType{s: "foo", n: 3, f: 2.0, arr: []string{"a", "b"}}, cmp.AllowUnexported(myCustomType{})))
-			Expect(myCustomType{s: "foo", n: 3, f: 2.0, arr: []string{"a", "b"}}).ShouldNot(BeComparableTo(myCustomType{s: "bar", n: 3, f: 2.0, arr: []string{"a", "b"}}, cmp.AllowUnexported(myCustomType{})))
-			Expect(myCustomType{s: "foo", n: 3, f: 2.0, arr: []string{"a", "b"}}).ShouldNot(BeComparableTo(myCustomType{s: "foo", n: 2, f: 2.0, arr: []string{"a", "b"}}, cmp.AllowUnexported(myCustomType{})))
-			Expect(myCustomType{s: "foo", n: 3, f: 2.0, arr: []string{"a", "b"}}).ShouldNot(BeComparableTo(myCustomType{s: "foo", n: 3, f: 3.0, arr: []string{"a", "b"}}, cmp.AllowUnexported(myCustomType{})))
-			Expect(myCustomType{s: "foo", n: 3, f: 2.0, arr: []string{"a", "b"}}).ShouldNot(BeComparableTo(myCustomType{s: "foo", n: 3, f: 2.0, arr: []string{"a", "b", "c"}}, cmp.AllowUnexported(myCustomType{})))
+				Expect(myCustomType{s: "foo", n: 3, f: 2.0, arr: []string{"a", "b"}}).Should(BeComparableTo(myCustomType{s: "foo", n: 3, f: 2.0, arr: []string{"a", "b"}}, cmp.AllowUnexported(myCustomType{})))
+				Expect(myCustomType{s: "foo", n: 3, f: 2.0, arr: []string{"a", "b"}}).ShouldNot(BeComparableTo(myCustomType{s: "bar", n: 3, f: 2.0, arr: []string{"a", "b"}}, cmp.AllowUnexported(myCustomType{})))
+				Expect(myCustomType{s: "foo", n: 3, f: 2.0, arr: []string{"a", "b"}}).ShouldNot(BeComparableTo(myCustomType{s: "foo", n: 2, f: 2.0, arr: []string{"a", "b"}}, cmp.AllowUnexported(myCustomType{})))
+				Expect(myCustomType{s: "foo", n: 3, f: 2.0, arr: []string{"a", "b"}}).ShouldNot(BeComparableTo(myCustomType{s: "foo", n: 3, f: 3.0, arr: []string{"a", "b"}}, cmp.AllowUnexported(myCustomType{})))
+				Expect(myCustomType{s: "foo", n: 3, f: 2.0, arr: []string{"a", "b"}}).ShouldNot(BeComparableTo(myCustomType{s: "foo", n: 3, f: 2.0, arr: []string{"a", "b", "c"}}, cmp.AllowUnexported(myCustomType{})))
+			})
+
+			type structWithUnexportedFields struct {
+				unexported string
+				Exported   string
+			}
+
+			It("should produce failure message according to paseed cmp.Option", func() {
+				actual := structWithUnexportedFields{unexported: "xxx", Exported: "exported field value"}
+				expectedEqual := structWithUnexportedFields{unexported: "yyy", Exported: "exported field value"}
+				matcherWithEqual := BeComparableTo(expectedEqual, cmpopts.IgnoreUnexported(structWithUnexportedFields{}))
+
+				Expect(matcherWithEqual.FailureMessage(actual)).To(BeEmpty())
+
+				expectedDiffernt := structWithUnexportedFields{unexported: "xxx", Exported: "other value"}
+				matcherWithDifference := BeComparableTo(expectedDiffernt, cmpopts.IgnoreUnexported(structWithUnexportedFields{}))
+				Expect(matcherWithDifference.FailureMessage(actual)).To(ContainSubstring("1 ignored field"))
+				Expect(matcherWithDifference.FailureMessage(actual)).To(ContainSubstring("Exported: \"other value\""))
+				Expect(matcherWithDifference.FailureMessage(actual)).To(ContainSubstring("Exported: \"exported field value\""))
+			})
 		})
 	})
 })


### PR DESCRIPTION
Small fix to [this PR](https://github.com/onsi/gomega/pull/546) introduced @xiantank.
As additional `cmp.Options` might be passed to `cmp.Equal` method, the same should be passed to `cmp.Diff`. 
In worst cases, lacking of options might cause a panic; eg. while using
```golang
type structWithUnexportedFields struct {
    unexported string
    Exported   string
}

actual := structWithUnexportedFields{unexported: "xxx", Exported: "exported field value"}
expectedEqual := structWithUnexportedFields{unexported: "yyy", Exported: "exported field value"}
Expect(actual).To(BeComparableTo(expectedEqual, cmpopts.IgnoreUnexported(structWithUnexportedFields{}))
```
If the exported values were different, `cmp.Equal` returns `false` and `FailureMessage` will panic because `cmp.Diff` can't handle unexported fields.

