### PR TITLE
Enable reading from a closed gbytes.Buffer

### DIFF
--- a/gbytes/buffer.go
+++ b/gbytes/buffer.go
@@ -87,16 +87,10 @@ func (b *Buffer) Write(p []byte) (n int, err error) {
 /*
 Read implements the io.Reader interface. It advances the
 cursor as it reads.
-
-Returns an error if called after Close.
 */
 func (b *Buffer) Read(d []byte) (int, error) {
 	b.lock.Lock()
 	defer b.lock.Unlock()
-
-	if b.closed {
-		return 0, errors.New("attempt to read from closed buffer")
-	}
 
 	if uint64(len(b.contents)) <= b.readCursor {
 		return 0, io.EOF

--- a/gbytes/buffer_test.go
+++ b/gbytes/buffer_test.go
@@ -105,19 +105,6 @@ var _ = Describe("Buffer", func() {
 			Expect(err).Should(Equal(io.EOF))
 			Expect(n).Should(Equal(0))
 		})
-
-		Context("after the buffer has been closed", func() {
-			It("returns an error", func() {
-				buffer := BufferWithBytes([]byte("abcde"))
-
-				buffer.Close()
-
-				dest := make([]byte, 3)
-				n, err := buffer.Read(dest)
-				Expect(err).Should(HaveOccurred())
-				Expect(n).Should(Equal(0))
-			})
-		})
 	})
 
 	Describe("detecting regular expressions", func() {


### PR DESCRIPTION
## Summary

PR addresses #573. I thought about updating the test case to ensure that a closed buffer can be read, but I later thought that the test case might not exist in the first place if we enabled reading from a closed buffer when the `Read` was added (i.e., 8 years ago), so I decided to completely remove the test case.

## Test

```sh
$ ginkgo -r -p
Running Suite: Gbytes Suite - D:\main\dev\davidhsingyuchen\gomega\gbytes
========================================================================
Random Seed: 1661405848

Will run 39 of 39 specs
Running in parallel across 11 processes
+++++++++++++++++++++++++++++++++++++++

Ran 39 of 39 Specs in 0.245 seconds
SUCCESS! -- 39 Passed | 0 Failed | 0 Pending | 0 Skipped


Ginkgo ran 1 suite in 3.3358401s
Test Suite Passed
```