### PR TITLE
Document acceptable string-like types for string matchers

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -193,9 +193,9 @@ func MatchRegexp(regexp string, args ...interface{}) types.GomegaMatcher {
 	}
 }
 
-// ContainSubstring succeeds if actual is a string or stringer that contains the
-// passed-in substring.  Optional arguments can be provided to construct the substring
-// via fmt.Sprintf().
+// ContainSubstring succeeds if actual is a string, stringer, []bytes, or json.RawMessage
+// that contains the passed-in substring.
+// Optional arguments can be provided to construct the substring via fmt.Sprintf().
 func ContainSubstring(substr string, args ...interface{}) types.GomegaMatcher {
 	return &matchers.ContainSubstringMatcher{
 		Substr: substr,
@@ -203,9 +203,9 @@ func ContainSubstring(substr string, args ...interface{}) types.GomegaMatcher {
 	}
 }
 
-// HavePrefix succeeds if actual is a string or stringer that contains the
-// passed-in string as a prefix.  Optional arguments can be provided to construct
-// via fmt.Sprintf().
+// HavePrefix succeeds if actual is a string, stringer, []bytes, or json.RawMessage
+// that contains the passed-in string as a prefix.
+// Optional arguments can be provided to construct the substring via fmt.Sprintf().
 func HavePrefix(prefix string, args ...interface{}) types.GomegaMatcher {
 	return &matchers.HavePrefixMatcher{
 		Prefix: prefix,
@@ -213,9 +213,9 @@ func HavePrefix(prefix string, args ...interface{}) types.GomegaMatcher {
 	}
 }
 
-// HaveSuffix succeeds if actual is a string or stringer that contains the
-// passed-in string as a suffix.  Optional arguments can be provided to construct
-// via fmt.Sprintf().
+// HaveSuffix succeeds if actual is a string, stringer, []bytes, or json.RawMessage
+// that contains the passed-in string as a suffix.
+// Optional arguments can be provided to construct the substring via fmt.Sprintf().
 func HaveSuffix(suffix string, args ...interface{}) types.GomegaMatcher {
 	return &matchers.HaveSuffixMatcher{
 		Suffix: suffix,

--- a/matchers/contain_substring_matcher.go
+++ b/matchers/contain_substring_matcher.go
@@ -17,7 +17,8 @@ type ContainSubstringMatcher struct {
 func (matcher *ContainSubstringMatcher) Match(actual interface{}) (success bool, err error) {
 	actualString, ok := toString(actual)
 	if !ok {
-		return false, fmt.Errorf("ContainSubstring matcher requires a string or stringer.  Got:\n%s", format.Object(actual, 1))
+		return false, fmt.Errorf("ContainSubstring matcher requires a string, stringer, []bytes, or json.RawMessage. "+
+			"Got:\n%s", format.Object(actual, 1))
 	}
 
 	return strings.Contains(actualString, matcher.stringToMatch()), nil

--- a/matchers/have_prefix_matcher.go
+++ b/matchers/have_prefix_matcher.go
@@ -14,7 +14,8 @@ type HavePrefixMatcher struct {
 func (matcher *HavePrefixMatcher) Match(actual interface{}) (success bool, err error) {
 	actualString, ok := toString(actual)
 	if !ok {
-		return false, fmt.Errorf("HavePrefix matcher requires a string or stringer.  Got:\n%s", format.Object(actual, 1))
+		return false, fmt.Errorf("HavePrefix matcher requires a string, stringer, []bytes, or json.RawMessage. "+
+			"Got:\n%s", format.Object(actual, 1))
 	}
 	prefix := matcher.prefix()
 	return len(actualString) >= len(prefix) && actualString[0:len(prefix)] == prefix, nil

--- a/matchers/have_suffix_matcher.go
+++ b/matchers/have_suffix_matcher.go
@@ -14,7 +14,8 @@ type HaveSuffixMatcher struct {
 func (matcher *HaveSuffixMatcher) Match(actual interface{}) (success bool, err error) {
 	actualString, ok := toString(actual)
 	if !ok {
-		return false, fmt.Errorf("HaveSuffix matcher requires a string or stringer.  Got:\n%s", format.Object(actual, 1))
+		return false, fmt.Errorf("HaveSuffix matcher requires a string, stringer, []bytes, or json.RawMessage. "+
+			"Got:\n%s", format.Object(actual, 1))
 	}
 	suffix := matcher.suffix()
 	return len(actualString) >= len(suffix) && actualString[len(actualString)-len(suffix):] == suffix, nil


### PR DESCRIPTION
## Summary

PR adds `[]bytes` and `json.RawMessage` as acceptable string types to function comments and error messages. They come from the implementation of [`toString`](https://github.com/onsi/gomega/blob/604aef4a4f98e4c468742c5c664a7549128a6123/matchers/type_support.go#L124).

## Notes

I noticed that `toString` is also used in matchers other than the ones updated in this PR, but I feel it's a bit weird to mention `json.RawMessage` in other matchers [like an YAML matcher](https://github.com/onsi/gomega/blob/604aef4a4f98e4c468742c5c664a7549128a6123/matchers/match_yaml_matcher.go#L66), so I decided to only update string-related matchers.

