### PR TITLE
Docs: Fix typo "MUltiple" -> "Multiple"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -148,7 +148,7 @@ Or you can write:
 Assertions about errors on functions with multiple return values can be made as follows (and in a lazy way when not asserting that all other return values are zero values):
 
 ```go
-_, _, _, err := MUltipleReturnValuesFunc()
+_, _, _, err := MultipleReturnValuesFunc()
 Ω(err).Should(HaveOccurred())
 ```
 


### PR DESCRIPTION
MUltipleReturnValuesFunc -> MultipleReturnValuesFunc

Just a small typo in the docs