### PR TITLE
compare unwrapped errors using DeepEqual

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -794,7 +794,9 @@ succeeds if `ACTUAL` is a non-nil `error` that matches `EXPECTED`. `EXPECTED` mu
 
 - A string, in which case `ACTUAL.Error()` will be compared against `EXPECTED`.
 - A matcher, in which case `ACTUAL.Error()` is tested against the matcher.
-- An error, in which case `ACTUAL` and `EXPECTED` are compared via `reflect.DeepEqual()`. If they are not deeply equal, they are tested by `errors.Is(ACTUAL, EXPECTED)`. (The latter allows to test whether `ACTUAL` wraps an `EXPECTED` error.)
+- An error, in which case the following is satisfied:
+    - `errors.Is(ACTUAL, EXPECTED)` returns `true`
+    - `ACTUAL` or any of the errors it wraps (directly or indirectly) equals `EXPECTED` in terms of `reflect.DeepEqual()`.
 
 Any other type for `EXPECTED` is an error.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -794,7 +794,7 @@ succeeds if `ACTUAL` is a non-nil `error` that matches `EXPECTED`. `EXPECTED` mu
 
 - A string, in which case `ACTUAL.Error()` will be compared against `EXPECTED`.
 - A matcher, in which case `ACTUAL.Error()` is tested against the matcher.
-- An error, in which case the following is satisfied:
+- An error, in which case anyo of the following is satisfied:
     - `errors.Is(ACTUAL, EXPECTED)` returns `true`
     - `ACTUAL` or any of the errors it wraps (directly or indirectly) equals `EXPECTED` in terms of `reflect.DeepEqual()`.
 

--- a/matchers/match_error_matcher.go
+++ b/matchers/match_error_matcher.go
@@ -25,7 +25,17 @@ func (matcher *MatchErrorMatcher) Match(actual interface{}) (success bool, err e
 	expected := matcher.Expected
 
 	if isError(expected) {
-		return reflect.DeepEqual(actualErr, expected) || errors.Is(actualErr, expected.(error)), nil
+		// first try the built-in errors.Is
+		if errors.Is(actualErr, expected.(error)) {
+			return true, nil
+		}
+		// if not, try DeepEqual along the error chain
+		for unwrapped := actualErr; unwrapped != nil; unwrapped = errors.Unwrap(unwrapped) {
+			if reflect.DeepEqual(unwrapped, expected) {
+				return true, nil
+			}
+		}
+		return false, nil
 	}
 
 	if isString(expected) {

--- a/matchers/match_error_matcher_test.go
+++ b/matchers/match_error_matcher_test.go
@@ -16,6 +16,14 @@ func (c CustomError) Error() string {
 	return "an error"
 }
 
+type ComplexError struct {
+	Key string
+}
+
+func (t *ComplexError) Error() string {
+	return fmt.Sprintf("err: %s", t.Key)
+}
+
 var _ = Describe("MatchErrorMatcher", func() {
 	Context("When asserting against an error", func() {
 		When("passed an error", func() {
@@ -36,6 +44,12 @@ var _ = Describe("MatchErrorMatcher", func() {
 				outerErr := fmt.Errorf("outer error wrapping: %w", innerErr)
 
 				Expect(outerErr).Should(MatchError(innerErr))
+			})
+
+			It("uses deep equality with unwrapped errors", func() {
+				innerErr := &ComplexError{Key: "abc"}
+				outerErr := fmt.Errorf("outer error wrapping: %w", &ComplexError{Key: "abc"})
+				Expect(outerErr).To(MatchError(innerErr))
 			})
 		})
 
@@ -130,6 +144,7 @@ var _ = Describe("MatchErrorMatcher", func() {
 		})
 		Expect(failuresMessages[0]).To(ContainSubstring("{s: \"foo\"}\nnot to match error\n    <string>: foo"))
 	})
+
 })
 
 type mockErr string


### PR DESCRIPTION
Currently when the actual error is check by `MatchError`, it matches in two cases:
1. The built-in `errors.Is(..)` returns true
2. the actual error deep-equals the matcher error

this change expands the second case and performs `DeepEqual` on each error in the chain of unwrapping. This allows matching complex errors that are wrapped, for example:
```go
err := fmt.Errorf("internal error: %w", MyKeyError{Key: "alice})

Expect(err).To(MatchError(MyKeyError{Key: "alice}))
```