### PR TITLE
docs(dsl): correct godoc comment on Expect func

### DIFF
--- a/gomega_dsl.go
+++ b/gomega_dsl.go
@@ -204,7 +204,7 @@ func Ω(actual interface{}, extra ...interface{}) Assertion {
 // All subsequent arguments will be required to be nil/zero.
 //
 // This is convenient if you want to make an assertion on a method/function that returns
-// a value and an error - a common patter in Go.
+// a value and an error - a common pattern in Go.
 //
 // For example, given a function with signature:
 //


### PR DESCRIPTION
Correct typo in GoDoc: patter -> pattern