### PR TITLE
Fix HaveExactElements to work inside ContainElement or other collection matchers

### DIFF
--- a/matchers/have_exact_elements.go
+++ b/matchers/have_exact_elements.go
@@ -19,6 +19,8 @@ type HaveExactElementsMatcher struct {
 }
 
 func (matcher *HaveExactElementsMatcher) Match(actual interface{}) (success bool, err error) {
+	matcher.resetState()
+
 	if isMap(actual) {
 		return false, fmt.Errorf("error")
 	}
@@ -72,4 +74,10 @@ func (matcher *HaveExactElementsMatcher) FailureMessage(actual interface{}) (mes
 
 func (matcher *HaveExactElementsMatcher) NegatedFailureMessage(actual interface{}) (message string) {
 	return format.Message(actual, "not to contain elements", presentable(matcher.Elements))
+}
+
+func (matcher *HaveExactElementsMatcher) resetState() {
+	matcher.mismatchFailures = nil
+	matcher.missingIndex = 0
+	matcher.extraIndex = 0
 }

--- a/matchers/have_exact_elements_test.go
+++ b/matchers/have_exact_elements_test.go
@@ -110,4 +110,14 @@ to equal
 			})
 		})
 	})
+
+	When("matcher instance is reused", func() {
+		// This is a regression test for https://github.com/onsi/gomega/issues/647.
+		// Matcher instance may be reused, if placed inside ContainElement() or other collection matchers.
+		It("should work properly", func() {
+			matchSingleFalse := HaveExactElements(Equal(false))
+			Expect([]bool{true}).ShouldNot(matchSingleFalse)
+			Expect([]bool{false}).Should(matchSingleFalse)
+		})
+	})
 })


### PR DESCRIPTION
Fixes #647

As described in #647, HaveExactElements() leaves some internal state once its Match() returns false. The state never gets cleaned afterwards and causes subsequent calls on the instance to return incorrect results. This can be a problem when the matcher is placed inside ContainElement() or any other matchers that reuse and call inner matcher instances multiple times.

This PR fixes the issue by resetting the matcher state at the beginning of the HaveExactElements#Match().