### PR TITLE
Typo in matchers.go

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -94,7 +94,7 @@ func Succeed() types.GomegaMatcher {
 //
 //	Expect(err).Should(MatchError("an error")) //asserts that err.Error() == "an error"
 //	Expect(err).Should(MatchError(SomeError)) //asserts that err == SomeError (via reflect.DeepEqual)
-//	Expect(err).Should(MatchError(ContainSubstring("sprocket not found"))) // asserts that edrr.Error() contains substring "sprocket not found"
+//	Expect(err).Should(MatchError(ContainSubstring("sprocket not found"))) // asserts that err.Error() contains substring "sprocket not found"
 //
 // It is an error for err to be nil or an object that does not implement the
 // Error interface


### PR DESCRIPTION
Minor typo in a comment