### PR TITLE
docs: fix `HaveExactElement` typo

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -394,7 +394,7 @@ func ConsistOf(elements ...interface{}) types.GomegaMatcher {
 	}
 }
 
-// HaveExactElemets succeeds if actual contains elements that precisely match the elemets passed into the matcher. The ordering of the elements does matter.
+// HaveExactElements succeeds if actual contains elements that precisely match the elemets passed into the matcher. The ordering of the elements does matter.
 // By default HaveExactElements() uses Equal() to match the elements, however custom matchers can be passed in instead.  Here are some examples:
 //
 //	Expect([]string{"Foo", "FooBar"}).Should(HaveExactElements("Foo", "FooBar"))


### PR DESCRIPTION
As title 👍