### PR TITLE
Inverted arguments order of FailureMessage of BeComparableToMatcher

### DIFF
--- a/matchers/be_comparable_to_matcher.go
+++ b/matchers/be_comparable_to_matcher.go
@@ -41,9 +41,9 @@ func (matcher *BeComparableToMatcher) Match(actual interface{}) (success bool, m
 }
 
 func (matcher *BeComparableToMatcher) FailureMessage(actual interface{}) (message string) {
-	return cmp.Diff(matcher.Expected, actual, matcher.Options)
+	return fmt.Sprint("Expected object to be comparable, diff: ", cmp.Diff(actual, matcher.Expected, matcher.Options...))
 }
 
 func (matcher *BeComparableToMatcher) NegatedFailureMessage(actual interface{}) (message string) {
-	return format.Message(actual, "not to equal", matcher.Expected)
+	return format.Message(actual, "not to be comparable to", matcher.Expected)
 }

--- a/matchers/be_comparable_to_matcher_test.go
+++ b/matchers/be_comparable_to_matcher_test.go
@@ -138,12 +138,12 @@ var _ = Describe("BeComparableTo", func() {
 				Exported   string
 			}
 
-			It("should produce failure message according to paseed cmp.Option", func() {
+			It("should produce failure message according to passed cmp.Option", func() {
 				actual := structWithUnexportedFields{unexported: "xxx", Exported: "exported field value"}
 				expectedEqual := structWithUnexportedFields{unexported: "yyy", Exported: "exported field value"}
 				matcherWithEqual := BeComparableTo(expectedEqual, cmpopts.IgnoreUnexported(structWithUnexportedFields{}))
 
-				Expect(matcherWithEqual.FailureMessage(actual)).To(BeEmpty())
+				Expect(matcherWithEqual.FailureMessage(actual)).To(BeEquivalentTo("Expected object to be comparable, diff: "))
 
 				expectedDiffernt := structWithUnexportedFields{unexported: "xxx", Exported: "other value"}
 				matcherWithDifference := BeComparableTo(expectedDiffernt, cmpopts.IgnoreUnexported(structWithUnexportedFields{}))


### PR DESCRIPTION
BeComparableTo behaved differently between Match and FailureMessage which made asymmetric go-cmp Options (e.g. https://pkg.go.dev/k8s.io/apimachinery/pkg/util/diff#IgnoreUnset) print a nonsensical error message.

Fixed this issue by inverting order or comparison, and improved a bit messages.

Fixes #719. 