### PR TITLE
chore: test with Go 1.22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,14 +9,14 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.20'
+        go-version: 'oldstable'
     - uses: actions/checkout@v4
     - run: go mod tidy && git diff --exit-code go.mod go.sum
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ '1.20', '1.21' ]
+        version: [ 'oldstable', 'stable' ]
     name: Go ${{ matrix.version }}
     steps:
     - uses: actions/setup-go@v5


### PR DESCRIPTION
- Rather than hard-coding the Go version in the workflow, we will use the stable and oldstable tags which today resolve to 1.22.0 and 1.21.7, but will float as Go versions change.