### PR TITLE
Replace min/max helpers with built-in min/max

### DIFF
--- a/gmeasure/table/table.go
+++ b/gmeasure/table/table.go
@@ -355,16 +355,3 @@ func sum(s []int) int {
 	return out
 }
 
-func min(a int, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max(a int, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}


### PR DESCRIPTION
We can use the built-in `min` and `max` functions since Go 1.21.

Reference: https://go.dev/ref/spec#Min_and_max