### PR TITLE
new: make collection-related matchers Go 1.23 iterator aware, resolves onsi/gomega#795

### DIFF
--- a/matchers/be_empty_matcher.go
+++ b/matchers/be_empty_matcher.go
@@ -4,17 +4,31 @@ package matchers
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/matchers/internal/miter"
 )
 
 type BeEmptyMatcher struct {
 }
 
 func (matcher *BeEmptyMatcher) Match(actual interface{}) (success bool, err error) {
+	// short-circuit the iterator case, as we only need to see the first
+	// element, if any.
+	if miter.IsIter(actual) {
+		var length int
+		if miter.IsSeq2(actual) {
+			miter.IterateKV(actual, func(k, v reflect.Value) bool { length++; return false })
+		} else {
+			miter.IterateV(actual, func(v reflect.Value) bool { length++; return false })
+		}
+		return length == 0, nil
+	}
+
 	length, ok := lengthOf(actual)
 	if !ok {
-		return false, fmt.Errorf("BeEmpty matcher expects a string/array/map/channel/slice.  Got:\n%s", format.Object(actual, 1))
+		return false, fmt.Errorf("BeEmpty matcher expects a string/array/map/channel/slice/iterator.  Got:\n%s", format.Object(actual, 1))
 	}
 
 	return length == 0, nil

--- a/matchers/be_empty_matcher_test.go
+++ b/matchers/be_empty_matcher_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/matchers"
+	"github.com/onsi/gomega/matchers/internal/miter"
 )
 
 var _ = Describe("BeEmpty", func() {
@@ -47,6 +48,34 @@ var _ = Describe("BeEmpty", func() {
 			success, err = (&BeEmptyMatcher{}).Match(nil)
 			Expect(success).Should(BeFalse())
 			Expect(err).Should(HaveOccurred())
+		})
+	})
+
+	Context("iterators", func() {
+		BeforeEach(func() {
+			if !miter.HasIterators() {
+				Skip("iterators not available")
+			}
+		})
+
+		When("passed an iterator type", func() {
+			It("should do the right thing", func() {
+				Expect(emptyIter).To(BeEmpty())
+				Expect(emptyIter2).To(BeEmpty())
+
+				Expect(universalIter).NotTo(BeEmpty())
+				Expect(universalIter2).NotTo(BeEmpty())
+			})
+		})
+
+		When("passed a correctly typed nil", func() {
+			It("should be true", func() {
+				var nilIter func(func(string) bool)
+				Expect(nilIter).Should(BeEmpty())
+
+				var nilIter2 func(func(int, string) bool)
+				Expect(nilIter2).Should(BeEmpty())
+			})
 		})
 	})
 })

--- a/matchers/consist_of_test.go
+++ b/matchers/consist_of_test.go
@@ -3,6 +3,7 @@ package matchers_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/matchers/internal/miter"
 )
 
 var _ = Describe("ConsistOf", func() {
@@ -193,6 +194,44 @@ the extra elements were
 
 				expected := `not to consist of\n\s*<\[\]interface {} \| len:2, cap:2>: \[<int>1, <string>"B"\]`
 				Expect(failures).To(ConsistOf(MatchRegexp(expected)))
+			})
+		})
+	})
+
+	Context("iterators", func() {
+		BeforeEach(func() {
+			if !miter.HasIterators() {
+				Skip("iterators not available")
+			}
+		})
+
+		Context("with an iter.Seq", func() {
+			It("should do the right thing", func() {
+				Expect(universalIter).Should(ConsistOf("foo", "bar", "baz"))
+				Expect(universalIter).Should(ConsistOf("foo", "bar", "baz"))
+				Expect(universalIter).Should(ConsistOf("baz", "bar", "foo"))
+				Expect(universalIter).ShouldNot(ConsistOf("baz", "bar", "foo", "foo"))
+				Expect(universalIter).ShouldNot(ConsistOf("baz", "foo"))
+			})
+		})
+
+		Context("with an iter.Seq2", func() {
+			It("should do the right thing", func() {
+				Expect(universalIter2).Should(ConsistOf("foo", "bar", "baz"))
+				Expect(universalIter2).Should(ConsistOf("foo", "bar", "baz"))
+				Expect(universalIter2).Should(ConsistOf("baz", "bar", "foo"))
+				Expect(universalIter2).ShouldNot(ConsistOf("baz", "bar", "foo", "foo"))
+				Expect(universalIter2).ShouldNot(ConsistOf("baz", "foo"))
+			})
+		})
+
+		When("passed exactly one argument, and that argument is an iter.Seq", func() {
+			It("should match against the elements of that argument", func() {
+				Expect(universalIter).Should(ConsistOf(universalIter))
+				Expect(universalIter).ShouldNot(ConsistOf(fooElements))
+
+				Expect(universalIter2).Should(ConsistOf(universalIter))
+				Expect(universalIter2).ShouldNot(ConsistOf(fooElements))
 			})
 		})
 	})

--- a/matchers/contain_element_matcher.go
+++ b/matchers/contain_element_matcher.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/matchers/internal/miter"
 )
 
 type ContainElementMatcher struct {
@@ -16,16 +17,18 @@ type ContainElementMatcher struct {
 }
 
 func (matcher *ContainElementMatcher) Match(actual interface{}) (success bool, err error) {
-	if !isArrayOrSlice(actual) && !isMap(actual) {
-		return false, fmt.Errorf("ContainElement matcher expects an array/slice/map.  Got:\n%s", format.Object(actual, 1))
+	if !isArrayOrSlice(actual) && !isMap(actual) && !miter.IsIter(actual) {
+		return false, fmt.Errorf("ContainElement matcher expects an array/slice/map/iterator.  Got:\n%s", format.Object(actual, 1))
 	}
 
 	var actualT reflect.Type
 	var result reflect.Value
-	switch l := len(matcher.Result); {
-	case l > 1:
+	switch numResultArgs := len(matcher.Result); {
+	case numResultArgs > 1:
 		return false, errors.New("ContainElement matcher expects at most a single optional pointer to store its findings at")
-	case l == 1:
+	case numResultArgs == 1:
+		// Check the optional result arg to point to a single value/array/slice/map
+		// of a type compatible with the actual value.
 		if reflect.ValueOf(matcher.Result[0]).Kind() != reflect.Ptr {
 			return false, fmt.Errorf("ContainElement matcher expects a non-nil pointer to store its findings at.  Got\n%s",
 				format.Object(matcher.Result[0], 1))
@@ -34,93 +37,209 @@ func (matcher *ContainElementMatcher) Match(actual interface{}) (success bool, e
 		resultReference := matcher.Result[0]
 		result = reflect.ValueOf(resultReference).Elem() // what ResultReference points to, to stash away our findings
 		switch result.Kind() {
-		case reflect.Array:
+		case reflect.Array: // result arrays are not supported, as they cannot be dynamically sized.
+			if miter.IsIter(actual) {
+				_, actualvT := miter.IterKVTypes(actual)
+				return false, fmt.Errorf("ContainElement cannot return findings.  Need *%s, got *%s",
+					reflect.SliceOf(actualvT), result.Type().String())
+			}
 			return false, fmt.Errorf("ContainElement cannot return findings.  Need *%s, got *%s",
 				reflect.SliceOf(actualT.Elem()).String(), result.Type().String())
-		case reflect.Slice:
-			if !isArrayOrSlice(actual) {
+
+		case reflect.Slice: // result slice
+			// can we assign elements in actual to elements in what the result
+			// arg points to?
+			//   - ✔ actual is an array or slice
+			//   - ✔ actual is an iter.Seq producing "v" elements
+			//   - ✔ actual is an iter.Seq2 producing "v" elements, ignoring
+			//     the "k" elements.
+			switch {
+			case isArrayOrSlice(actual):
+				if !actualT.Elem().AssignableTo(result.Type().Elem()) {
+					return false, fmt.Errorf("ContainElement cannot return findings.  Need *%s, got *%s",
+						actualT.String(), result.Type().String())
+				}
+
+			case miter.IsIter(actual):
+				_, actualvT := miter.IterKVTypes(actual)
+				if !actualvT.AssignableTo(result.Type().Elem()) {
+					return false, fmt.Errorf("ContainElement cannot return findings.  Need *%s, got *%s",
+						actualvT.String(), result.Type().String())
+				}
+
+			default: // incompatible result reference
 				return false, fmt.Errorf("ContainElement cannot return findings.  Need *%s, got *%s",
 					reflect.MapOf(actualT.Key(), actualT.Elem()).String(), result.Type().String())
 			}
-			if !actualT.Elem().AssignableTo(result.Type().Elem()) {
+
+		case reflect.Map: // result map
+			// can we assign elements in actual to elements in what the result
+			// arg points to?
+			//   - ✔ actual is a map
+			//   - ✔ actual is an iter.Seq2 (iter.Seq doesn't fit though)
+			switch {
+			case isMap(actual):
+				if !actualT.AssignableTo(result.Type()) {
+					return false, fmt.Errorf("ContainElement cannot return findings.  Need *%s, got *%s",
+						actualT.String(), result.Type().String())
+				}
+
+			case miter.IsIter(actual):
+				actualkT, actualvT := miter.IterKVTypes(actual)
+				if actualkT == nil {
+					return false, fmt.Errorf("ContainElement cannot return findings.  Need *%s, got *%s",
+						reflect.SliceOf(actualvT).String(), result.Type().String())
+				}
+				if !reflect.MapOf(actualkT, actualvT).AssignableTo(result.Type()) {
+					return false, fmt.Errorf("ContainElement cannot return findings.  Need *%s, got *%s",
+						reflect.MapOf(actualkT, actualvT), result.Type().String())
+				}
+
+			default: // incompatible result reference
 				return false, fmt.Errorf("ContainElement cannot return findings.  Need *%s, got *%s",
 					actualT.String(), result.Type().String())
 			}
-		case reflect.Map:
-			if !isMap(actual) {
-				return false, fmt.Errorf("ContainElement cannot return findings.  Need *%s, got *%s",
-					actualT.String(), result.Type().String())
-			}
-			if !actualT.AssignableTo(result.Type()) {
-				return false, fmt.Errorf("ContainElement cannot return findings.  Need *%s, got *%s",
-					actualT.String(), result.Type().String())
-			}
+
 		default:
-			if !actualT.Elem().AssignableTo(result.Type()) {
-				return false, fmt.Errorf("ContainElement cannot return findings.  Need *%s, got *%s",
-					actualT.Elem().String(), result.Type().String())
+			// can we assign a (single) element in actual to what the result arg
+			// points to?
+			switch {
+			case miter.IsIter(actual):
+				_, actualvT := miter.IterKVTypes(actual)
+				if !actualvT.AssignableTo(result.Type()) {
+					return false, fmt.Errorf("ContainElement cannot return findings.  Need *%s, got *%s",
+						actualvT.String(), result.Type().String())
+				}
+			default:
+				if !actualT.Elem().AssignableTo(result.Type()) {
+					return false, fmt.Errorf("ContainElement cannot return findings.  Need *%s, got *%s",
+						actualT.Elem().String(), result.Type().String())
+				}
 			}
 		}
 	}
 
+	// If the supplied matcher isn't an Omega matcher, default to the Equal
+	// matcher.
 	elemMatcher, elementIsMatcher := matcher.Element.(omegaMatcher)
 	if !elementIsMatcher {
 		elemMatcher = &EqualMatcher{Expected: matcher.Element}
 	}
 
 	value := reflect.ValueOf(actual)
-	var valueAt func(int) interface{}
 
-	var getFindings func() reflect.Value
-	var foundAt func(int)
+	var getFindings func() reflect.Value // abstracts how the findings are collected and stored
+	var lastError error
 
-	if isMap(actual) {
-		keys := value.MapKeys()
-		valueAt = func(i int) interface{} {
-			return value.MapIndex(keys[i]).Interface()
-		}
-		if result.Kind() != reflect.Invalid {
-			fm := reflect.MakeMap(actualT)
-			getFindings = func() reflect.Value {
-				return fm
+	if !miter.IsIter(actual) {
+		var valueAt func(int) interface{}
+		var foundAt func(int)
+		// We're dealing with an array/slice/map, so in all cases we can iterate
+		// over the elements in actual using indices (that can be considered
+		// keys in case of maps).
+		if isMap(actual) {
+			keys := value.MapKeys()
+			valueAt = func(i int) interface{} {
+				return value.MapIndex(keys[i]).Interface()
 			}
-			foundAt = func(i int) {
-				fm.SetMapIndex(keys[i], value.MapIndex(keys[i]))
+			if result.Kind() != reflect.Invalid {
+				fm := reflect.MakeMap(actualT)
+				getFindings = func() reflect.Value { return fm }
+				foundAt = func(i int) {
+					fm.SetMapIndex(keys[i], value.MapIndex(keys[i]))
+				}
+			}
+		} else {
+			valueAt = func(i int) interface{} {
+				return value.Index(i).Interface()
+			}
+			if result.Kind() != reflect.Invalid {
+				var fsl reflect.Value
+				if result.Kind() == reflect.Slice {
+					fsl = reflect.MakeSlice(result.Type(), 0, 0)
+				} else {
+					fsl = reflect.MakeSlice(reflect.SliceOf(result.Type()), 0, 0)
+				}
+				getFindings = func() reflect.Value { return fsl }
+				foundAt = func(i int) {
+					fsl = reflect.Append(fsl, value.Index(i))
+				}
+			}
+		}
+
+		for i := 0; i < value.Len(); i++ {
+			elem := valueAt(i)
+			success, err := elemMatcher.Match(elem)
+			if err != nil {
+				lastError = err
+				continue
+			}
+			if success {
+				if result.Kind() == reflect.Invalid {
+					return true, nil
+				}
+				foundAt(i)
 			}
 		}
 	} else {
-		valueAt = func(i int) interface{} {
-			return value.Index(i).Interface()
-		}
+		// We're dealing with an iterator as a first-class construct, so things
+		// are slightly different: there is no index defined as in case of
+		// arrays/slices/maps, just "ooooorder"
+		var found func(k, v reflect.Value)
 		if result.Kind() != reflect.Invalid {
-			var f reflect.Value
-			if result.Kind() == reflect.Slice {
-				f = reflect.MakeSlice(result.Type(), 0, 0)
+			if result.Kind() == reflect.Map {
+				fm := reflect.MakeMap(result.Type())
+				getFindings = func() reflect.Value { return fm }
+				found = func(k, v reflect.Value) { fm.SetMapIndex(k, v) }
 			} else {
-				f = reflect.MakeSlice(reflect.SliceOf(result.Type()), 0, 0)
-			}
-			getFindings = func() reflect.Value {
-				return f
-			}
-			foundAt = func(i int) {
-				f = reflect.Append(f, value.Index(i))
+				var fsl reflect.Value
+				if result.Kind() == reflect.Slice {
+					fsl = reflect.MakeSlice(result.Type(), 0, 0)
+				} else {
+					fsl = reflect.MakeSlice(reflect.SliceOf(result.Type()), 0, 0)
+				}
+				getFindings = func() reflect.Value { return fsl }
+				found = func(_, v reflect.Value) { fsl = reflect.Append(fsl, v) }
 			}
 		}
-	}
 
-	var lastError error
-	for i := 0; i < value.Len(); i++ {
-		elem := valueAt(i)
-		success, err := elemMatcher.Match(elem)
-		if err != nil {
-			lastError = err
-			continue
+		success := false
+		actualkT, _ := miter.IterKVTypes(actual)
+		if actualkT == nil {
+			miter.IterateV(actual, func(v reflect.Value) bool {
+				var err error
+				success, err = elemMatcher.Match(v.Interface())
+				if err != nil {
+					lastError = err
+					return true // iterate on...
+				}
+				if success {
+					if result.Kind() == reflect.Invalid {
+						return false // a match and no result needed, so we're done
+					}
+					found(reflect.Value{}, v)
+				}
+				return true // iterate on...
+			})
+		} else {
+			miter.IterateKV(actual, func(k, v reflect.Value) bool {
+				var err error
+				success, err = elemMatcher.Match(v.Interface())
+				if err != nil {
+					lastError = err
+					return true // iterate on...
+				}
+				if success {
+					if result.Kind() == reflect.Invalid {
+						return false // a match and no result needed, so we're done
+					}
+					found(k, v)
+				}
+				return true // iterate on...
+			})
 		}
-		if success {
-			if result.Kind() == reflect.Invalid {
-				return true, nil
-			}
-			foundAt(i)
+		if success && result.Kind() == reflect.Invalid {
+			return true, nil
 		}
 	}
 

--- a/matchers/contain_elements_matcher.go
+++ b/matchers/contain_elements_matcher.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/matchers/internal/miter"
 	"github.com/onsi/gomega/matchers/support/goraph/bipartitegraph"
 )
 
@@ -13,8 +14,8 @@ type ContainElementsMatcher struct {
 }
 
 func (matcher *ContainElementsMatcher) Match(actual interface{}) (success bool, err error) {
-	if !isArrayOrSlice(actual) && !isMap(actual) {
-		return false, fmt.Errorf("ContainElements matcher expects an array/slice/map.  Got:\n%s", format.Object(actual, 1))
+	if !isArrayOrSlice(actual) && !isMap(actual) && !miter.IsIter(actual) {
+		return false, fmt.Errorf("ContainElements matcher expects an array/slice/map/iter.Seq/iter.Seq2.  Got:\n%s", format.Object(actual, 1))
 	}
 
 	matchers := matchers(matcher.Elements)

--- a/matchers/contain_elements_matcher_test.go
+++ b/matchers/contain_elements_matcher_test.go
@@ -3,6 +3,7 @@ package matchers_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/matchers/internal/miter"
 )
 
 var _ = Describe("ContainElements", func() {
@@ -146,6 +147,42 @@ the missing elements were
 
 				expected := `not to contain elements\n\s*<\[\]interface {} \| len:2, cap:2>: \[<int>1, <string>"B"\]`
 				Expect(failures).To(ConsistOf(MatchRegexp(expected)))
+			})
+		})
+	})
+
+	Context("iterators", func() {
+		BeforeEach(func() {
+			if !miter.HasIterators() {
+				Skip("iterators not available")
+			}
+		})
+
+		Context("with an iter.Seq", func() {
+			It("should do the right thing", func() {
+				Expect(universalIter).Should(ContainElements("foo", "bar", "baz"))
+				Expect(universalIter).Should(ContainElements("bar"))
+				Expect(universalIter).Should(ContainElements())
+				Expect(universalIter).ShouldNot(ContainElements("baz", "bar", "foo", "foo"))
+			})
+		})
+
+		Context("with an iter.Seq2", func() {
+			It("should do the right thing", func() {
+				Expect(universalIter2).Should(ContainElements("foo", "bar", "baz"))
+				Expect(universalIter2).Should(ContainElements("bar"))
+				Expect(universalIter2).Should(ContainElements())
+				Expect(universalIter2).ShouldNot(ContainElements("baz", "bar", "foo", "foo"))
+			})
+		})
+
+		When("passed exactly one argument, and that argument is an iter.Seq", func() {
+			It("should match against the elements of that argument", func() {
+				Expect(universalIter).Should(ContainElements(universalIter))
+				Expect(universalIter).ShouldNot(ContainElements(fooElements))
+
+				Expect(universalIter2).Should(ContainElements(universalIter))
+				Expect(universalIter2).ShouldNot(ContainElements(fooElements))
 			})
 		})
 	})

--- a/matchers/have_exact_elements_test.go
+++ b/matchers/have_exact_elements_test.go
@@ -3,6 +3,7 @@ package matchers_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/matchers/internal/miter"
 )
 
 var _ = Describe("HaveExactElements", func() {
@@ -140,6 +141,154 @@ to equal
 			matchSingleFalse := HaveExactElements(Equal(false))
 			Expect([]bool{true}).ShouldNot(matchSingleFalse)
 			Expect([]bool{false}).Should(matchSingleFalse)
+		})
+	})
+
+	Context("iterators", func() {
+		BeforeEach(func() {
+			if !miter.HasIterators() {
+				Skip("iterators not available")
+			}
+		})
+
+		Context("with an iter.Seq", func() {
+			It("should do the right thing", func() {
+				Expect(universalIter).Should(HaveExactElements("foo", "bar", "baz"))
+				Expect(universalIter).ShouldNot(HaveExactElements("foo"))
+				Expect(universalIter).ShouldNot(HaveExactElements("foo", "bar", "baz", "argh"))
+				Expect(universalIter).ShouldNot(HaveExactElements("foo", "bar"))
+
+				var nilIter func(func(string) bool)
+				Expect(nilIter).Should(HaveExactElements())
+			})
+		})
+
+		Context("with an iter.Seq2", func() {
+			It("should error", func() {
+				failures := InterceptGomegaFailures(func() {
+					Expect(universalIter2).Should(HaveExactElements("foo"))
+				})
+
+				Expect(failures).Should(HaveLen(1))
+			})
+		})
+
+		When("passed matchers", func() {
+			It("should pass if matcher pass", func() {
+				Expect(universalIter).Should(HaveExactElements("foo", MatchRegexp("^ba"), MatchRegexp("az$")))
+				Expect(universalIter).ShouldNot(HaveExactElements("foo", MatchRegexp("az$"), MatchRegexp("^ba")))
+				Expect(universalIter).ShouldNot(HaveExactElements("foo", MatchRegexp("az$")))
+				Expect(universalIter).ShouldNot(HaveExactElements("foo", MatchRegexp("az$"), "baz", "bac"))
+			})
+
+			When("a matcher errors", func() {
+				It("should soldier on", func() {
+					Expect(universalIter).ShouldNot(HaveExactElements(BeFalse(), "bar", "baz"))
+					poly := []any{"foo", "bar", false}
+					polyIter := func(yield func(any) bool) {
+						for _, v := range poly {
+							if !yield(v) {
+								return
+							}
+						}
+					}
+					Expect(polyIter).Should(HaveExactElements(ContainSubstring("foo"), "bar", BeFalse()))
+				})
+
+				It("should include the error message, not the failure message", func() {
+					failures := InterceptGomegaFailures(func() {
+						Expect(universalIter).Should(HaveExactElements("foo", BeFalse(), "bar"))
+					})
+					Ω(failures[0]).ShouldNot(ContainSubstring("to be false"))
+					Ω(failures[0]).Should(ContainSubstring("1: Expected a boolean.  Got:\n    <string>: bar"))
+				})
+			})
+		})
+		When("passed exactly one argument, and that argument is a slice", func() {
+			It("should match against the elements of that arguments", func() {
+				Expect(universalIter).Should(HaveExactElements([]string{"foo", "bar", "baz"}))
+				Expect(universalIter).ShouldNot(HaveExactElements([]string{"foo", "bar"}))
+			})
+		})
+
+		When("passed nil", func() {
+			It("should fail correctly", func() {
+				failures := InterceptGomegaFailures(func() {
+					var expected []any
+					Expect(universalIter).Should(HaveExactElements(expected...))
+				})
+				Expect(failures).Should(HaveLen(1))
+			})
+		})
+
+		Describe("Failure Message", func() {
+			When("actual contains extra elements", func() {
+				It("should print the starting index of the extra elements", func() {
+					failures := InterceptGomegaFailures(func() {
+						Expect(universalIter).Should(HaveExactElements("foo"))
+					})
+
+					expected := "Expected\n.*<func\\(func\\(string\\) bool\\)>:.*\nto have exact elements with\n.*\\[\"foo\"\\]\nthe extra elements start from index 1"
+					Expect(failures).To(ConsistOf(MatchRegexp(expected)))
+				})
+			})
+
+			When("actual misses an element", func() {
+				It("should print the starting index of missing element", func() {
+					failures := InterceptGomegaFailures(func() {
+						Expect(universalIter).Should(HaveExactElements("foo", "bar", "baz", "argh"))
+					})
+
+					expected := "Expected\n.*<func\\(func\\(string\\) bool\\)>:.*\nto have exact elements with\n.*\\[\"foo\", \"bar\", \"baz\", \"argh\"\\]\nthe missing elements start from index 3"
+					Expect(failures).To(ConsistOf(MatchRegexp(expected)))
+				})
+			})
+		})
+
+		When("actual have mismatched elements", func() {
+			It("should print the index, expected element, and actual element", func() {
+				failures := InterceptGomegaFailures(func() {
+					Expect(universalIter).Should(HaveExactElements("bar", "baz", "foo"))
+				})
+
+				expected := `Expected
+.*<func\(func\(string\) bool\)>:.*
+to have exact elements with
+.*\["bar", "baz", "foo"\]
+the mismatch indexes were:
+0: Expected
+    <string>: foo
+to equal
+    <string>: bar
+1: Expected
+    <string>: bar
+to equal
+    <string>: baz
+2: Expected
+    <string>: baz
+to equal
+    <string>: foo`
+				Expect(failures[0]).To(MatchRegexp(expected))
+			})
+		})
+
+		When("matcher instance is reused", func() {
+			// This is a regression test for https://github.com/onsi/gomega/issues/647.
+			// Matcher instance may be reused, if placed inside ContainElement() or other collection matchers.
+			It("should work properly", func() {
+				matchSingleFalse := HaveExactElements(Equal(false))
+				allOf := func(a []bool) func(func(bool) bool) {
+					return func(yield func(bool) bool) {
+						for _, b := range a {
+							if !yield(b) {
+								return
+							}
+						}
+					}
+				}
+				Expect(allOf([]bool{true})).ShouldNot(matchSingleFalse)
+				Expect(allOf([]bool{false})).Should(matchSingleFalse)
+			})
 		})
 	})
 })

--- a/matchers/have_len_matcher.go
+++ b/matchers/have_len_matcher.go
@@ -13,7 +13,7 @@ type HaveLenMatcher struct {
 func (matcher *HaveLenMatcher) Match(actual interface{}) (success bool, err error) {
 	length, ok := lengthOf(actual)
 	if !ok {
-		return false, fmt.Errorf("HaveLen matcher expects a string/array/map/channel/slice.  Got:\n%s", format.Object(actual, 1))
+		return false, fmt.Errorf("HaveLen matcher expects a string/array/map/channel/slice/iterator.  Got:\n%s", format.Object(actual, 1))
 	}
 
 	return length == matcher.Count, nil

--- a/matchers/have_len_matcher_test.go
+++ b/matchers/have_len_matcher_test.go
@@ -1,6 +1,8 @@
 package matchers_test
 
 import (
+	"github.com/onsi/gomega/matchers/internal/miter"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/matchers"
@@ -48,6 +50,34 @@ var _ = Describe("HaveLen", func() {
 			success, err = (&HaveLenMatcher{Count: 0}).Match(nil)
 			Expect(success).Should(BeFalse())
 			Expect(err).Should(HaveOccurred())
+		})
+	})
+
+	Context("iterators", func() {
+		BeforeEach(func() {
+			if !miter.HasIterators() {
+				Skip("iterators not available")
+			}
+		})
+
+		When("passed an iterator type", func() {
+			It("should do the right thing", func() {
+				Expect(emptyIter).To(HaveLen(0))
+				Expect(emptyIter2).To(HaveLen(0))
+
+				Expect(universalIter).To(HaveLen(len(universalElements)))
+				Expect(universalIter2).To(HaveLen(len(universalElements)))
+			})
+		})
+
+		When("passed a correctly typed nil", func() {
+			It("should operate succesfully on the passed in value", func() {
+				var nilIter func(func(string) bool)
+				Expect(nilIter).Should(HaveLen(0))
+
+				var nilIter2 func(func(int, string) bool)
+				Expect(nilIter2).Should(HaveLen(0))
+			})
 		})
 	})
 })

--- a/matchers/internal/miter/miter_suite_test.go
+++ b/matchers/internal/miter/miter_suite_test.go
@@ -1,0 +1,13 @@
+package miter_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMatcherIter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Matcher Iter Support Suite")
+}

--- a/matchers/internal/miter/type_support_iter.go
+++ b/matchers/internal/miter/type_support_iter.go
@@ -1,0 +1,128 @@
+//go:build go1.23
+
+package miter
+
+import (
+	"reflect"
+)
+
+// HasIterators always returns false for Go versions before 1.23.
+func HasIterators() bool { return true }
+
+// IsIter returns true if the specified value is a function type that can be
+// range-d over, otherwise false.
+//
+// We don't use reflect's CanSeq and CanSeq2 directly, as these would return
+// true also for other value types that are range-able, such as integers,
+// slices, et cetera. Here, we aim only at range-able (iterator) functions.
+func IsIter(it any) bool {
+	if it == nil { // on purpose we only test for untyped nil.
+		return false
+	}
+	// reject all non-iterator-func values, even if they're range-able.
+	t := reflect.TypeOf(it)
+	if t.Kind() != reflect.Func {
+		return false
+	}
+	return t.CanSeq() || t.CanSeq2()
+}
+
+// IterKVTypes returns the reflection types of an iterator's yield function's K
+// and optional V arguments, otherwise nil K and V reflection types.
+func IterKVTypes(it any) (k, v reflect.Type) {
+	if it == nil {
+		return
+	}
+	// reject all non-iterator-func values, even if they're range-able.
+	t := reflect.TypeOf(it)
+	if t.Kind() != reflect.Func {
+		return
+	}
+	// get the reflection types for V, and where applicable, K.
+	switch {
+	case t.CanSeq():
+		v = t. /*iterator fn*/ In(0). /*yield fn*/ In(0)
+	case t.CanSeq2():
+		yieldfn := t. /*iterator fn*/ In(0)
+		k = yieldfn.In(0)
+		v = yieldfn.In(1)
+	}
+	return
+}
+
+// IsSeq2 returns true if the passed iterator function is compatible with
+// iter.Seq2, otherwise false.
+//
+// IsSeq2 hides the Go 1.23+ specific reflect.Type.CanSeq2 behind a facade which
+// is empty for Go versions before 1.23.
+func IsSeq2(it any) bool {
+	if it == nil {
+		return false
+	}
+	t := reflect.TypeOf(it)
+	return t.Kind() == reflect.Func && t.CanSeq2()
+}
+
+// isNilly returns true if v is either an untyped nil, or is a nil function (not
+// necessarily an iterator function).
+func isNilly(v any) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	return rv.Kind() == reflect.Func && rv.IsNil()
+}
+
+// IterateV loops over the elements produced by an iterator function, passing
+// the elements to the specified yield function individually and stopping only
+// when either the iterator function runs out of elements or the yield function
+// tell us to stop it.
+//
+// IterateV works very much like reflect.Value.Seq but hides the Go 1.23+
+// specific parts behind a facade which is empty for Go versions before 1.23, in
+// order to simplify code maintenance for matchers when using older Go versions.
+func IterateV(it any, yield func(v reflect.Value) bool) {
+	if isNilly(it) {
+		return
+	}
+	// reject all non-iterator-func values, even if they're range-able.
+	t := reflect.TypeOf(it)
+	if t.Kind() != reflect.Func || !t.CanSeq() {
+		return
+	}
+	// Call the specified iterator function, handing it our adaptor to call the
+	// specified generic reflection yield function.
+	reflectedYield := reflect.MakeFunc(
+		t. /*iterator fn*/ In(0),
+		func(args []reflect.Value) []reflect.Value {
+			return []reflect.Value{reflect.ValueOf(yield(args[0]))}
+		})
+	reflect.ValueOf(it).Call([]reflect.Value{reflectedYield})
+}
+
+// IterateKV loops over the key-value elements produced by an iterator function,
+// passing the elements to the specified yield function individually and
+// stopping only when either the iterator function runs out of elements or the
+// yield function tell us to stop it.
+//
+// IterateKV works very much like reflect.Value.Seq2 but hides the Go 1.23+
+// specific parts behind a facade which is empty for Go versions before 1.23, in
+// order to simplify code maintenance for matchers when using older Go versions.
+func IterateKV(it any, yield func(k, v reflect.Value) bool) {
+	if isNilly(it) {
+		return
+	}
+	// reject all non-iterator-func values, even if they're range-able.
+	t := reflect.TypeOf(it)
+	if t.Kind() != reflect.Func || !t.CanSeq2() {
+		return
+	}
+	// Call the specified iterator function, handing it our adaptor to call the
+	// specified generic reflection yield function.
+	reflectedYield := reflect.MakeFunc(
+		t. /*iterator fn*/ In(0),
+		func(args []reflect.Value) []reflect.Value {
+			return []reflect.Value{reflect.ValueOf(yield(args[0], args[1]))}
+		})
+	reflect.ValueOf(it).Call([]reflect.Value{reflectedYield})
+}

--- a/matchers/internal/miter/type_support_iter_test.go
+++ b/matchers/internal/miter/type_support_iter_test.go
@@ -1,0 +1,211 @@
+//go:build go1.23
+
+package miter_test
+
+import (
+	"reflect"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/onsi/gomega/matchers/internal/miter"
+)
+
+var _ = Describe("iterator function types", func() {
+
+	When("detecting iterator functions", func() {
+
+		It("doesn't match a nil value", func() {
+			Expect(IsIter(nil)).To(BeFalse())
+		})
+
+		It("doesn't match a range-able numeric value", func() {
+			Expect(IsIter(42)).To(BeFalse())
+		})
+
+		It("doesn't match a non-iter function", func() {
+			Expect(IsIter(func(yabadabadu string) {})).To(BeFalse())
+		})
+
+		It("matches an iter.Seq-like iter function", func() {
+			Expect(IsIter(func(yield func(v int) bool) {})).To(BeTrue())
+			var nilIter func(func(string) bool)
+			Expect(IsIter(nilIter)).To(BeTrue())
+		})
+
+		It("matches an iter.Seq2-like iter function", func() {
+			Expect(IsIter(func(yield func(k uint, v string) bool) {})).To(BeTrue())
+			var nilIter2 func(func(string, bool) bool)
+			Expect(IsIter(nilIter2)).To(BeTrue())
+		})
+
+	})
+
+	It("detects iter.Seq2", func() {
+		Expect(IsSeq2(42)).To(BeFalse())
+		Expect(IsSeq2(func(func(int) bool) {})).To(BeFalse())
+		Expect(IsSeq2(func(func(int, int) bool) {})).To(BeTrue())
+
+		var nilIter2 func(func(string, bool) bool)
+		Expect(IsSeq2(nilIter2)).To(BeTrue())
+	})
+
+	When("getting iterator function K, V types", func() {
+
+		It("has no types when nil", func() {
+			k, v := IterKVTypes(nil)
+			Expect(k).To(BeNil())
+			Expect(v).To(BeNil())
+		})
+
+		It("has no types for range-able numbers", func() {
+			k, v := IterKVTypes(42)
+			Expect(k).To(BeNil())
+			Expect(v).To(BeNil())
+		})
+
+		It("returns correct reflection type for the iterator's V", func() {
+			type foo uint
+			k, v := IterKVTypes(func(yield func(v foo) bool) {})
+			Expect(k).To(BeNil())
+			Expect(v).To(Equal(reflect.TypeOf(foo(42))))
+		})
+
+		It("returns correct reflection types for the iterator's K and V", func() {
+			type foo uint
+			type bar string
+			k, v := IterKVTypes(func(yield func(k foo, v bar) bool) {})
+			Expect(k).To(Equal(reflect.TypeOf(foo(42))))
+			Expect(v).To(Equal(reflect.TypeOf(bar(""))))
+		})
+
+	})
+
+	When("iterating single value reflections", func() {
+
+		iterelements := []string{"foo", "bar", "baz"}
+
+		it := func(yield func(v string) bool) {
+			for _, el := range iterelements {
+				if !yield(el) {
+					break
+				}
+			}
+		}
+
+		It("doesn't loop over a nil iterator", func() {
+			Expect(func() {
+				IterateV(nil, func(v reflect.Value) bool { panic("reflection yield must not be called") })
+			}).NotTo(Panic())
+		})
+
+		It("doesn't loop over a typed-nil iterator", func() {
+			var nilIter func(func(string) bool)
+			Expect(func() {
+				IterateV(nilIter, func(v reflect.Value) bool { panic("reflection yield must not be called") })
+			}).NotTo(Panic())
+		})
+
+		It("doesn't loop over a non-iterator value", func() {
+			Expect(func() {
+				IterateV(42, func(v reflect.Value) bool { panic("reflection yield must not be called") })
+			}).NotTo(Panic())
+		})
+
+		It("doesn't loop over an iter.Seq2", func() {
+			Expect(func() {
+				IterateV(
+					func(k uint, v string) bool { panic("it.Seq2 must not be called") },
+					func(v reflect.Value) bool { panic("reflection yield must not be called") })
+			}).NotTo(Panic())
+		})
+
+		It("yields all reflection values", func() {
+			els := []string{}
+			IterateV(it, func(v reflect.Value) bool {
+				els = append(els, v.String())
+				return true
+			})
+			Expect(els).To(ConsistOf(iterelements))
+		})
+
+		It("stops yielding reflection values before reaching THE END", func() {
+			els := []string{}
+			IterateV(it, func(v reflect.Value) bool {
+				els = append(els, v.String())
+				return len(els) < 2
+			})
+			Expect(els).To(ConsistOf(iterelements[:2]))
+		})
+
+	})
+
+	When("iterating key-value reflections", func() {
+
+		type kv struct {
+			k uint
+			v string
+		}
+
+		iterelements := []kv{
+			{k: 42, v: "foo"},
+			{k: 66, v: "bar"},
+			{k: 666, v: "baz"},
+		}
+
+		it := func(yield func(k uint, v string) bool) {
+			for _, el := range iterelements {
+				if !yield(el.k, el.v) {
+					break
+				}
+			}
+		}
+
+		It("doesn't loop over a nil iterator", func() {
+			Expect(func() {
+				IterateKV(nil, func(k, v reflect.Value) bool { panic("reflection yield must not be called") })
+			}).NotTo(Panic())
+		})
+
+		It("doesn't loop over a typed-nil iterator", func() {
+			var nilIter2 func(func(int, string) bool)
+			Expect(func() {
+				IterateKV(nilIter2, func(k, v reflect.Value) bool { panic("reflection yield must not be called") })
+			}).NotTo(Panic())
+		})
+
+		It("doesn't loop over a non-iterator value", func() {
+			Expect(func() {
+				IterateKV(42, func(k, v reflect.Value) bool { panic("reflection yield must not be called") })
+			}).NotTo(Panic())
+		})
+
+		It("doesn't loop over an iter.Seq", func() {
+			Expect(func() {
+				IterateKV(
+					func(v string) bool { panic("it.Seq must not be called") },
+					func(k, v reflect.Value) bool { panic("reflection yield must not be called") })
+			}).NotTo(Panic())
+		})
+
+		It("yields all reflection key-values", func() {
+			els := []kv{}
+			IterateKV(it, func(k, v reflect.Value) bool {
+				els = append(els, kv{k: uint(k.Uint()), v: v.String()})
+				return true
+			})
+			Expect(els).To(ConsistOf(iterelements))
+		})
+
+		It("stops yielding reflection key-values before reaching THE END", func() {
+			els := []kv{}
+			IterateKV(it, func(k, v reflect.Value) bool {
+				els = append(els, kv{k: uint(k.Uint()), v: v.String()})
+				return len(els) < 2
+			})
+			Expect(els).To(ConsistOf(iterelements[:2]))
+		})
+
+	})
+
+})

--- a/matchers/internal/miter/type_support_noiter.go
+++ b/matchers/internal/miter/type_support_noiter.go
@@ -1,0 +1,44 @@
+//go:build !go1.23
+
+/*
+Gomega matchers
+
+This package implements the Gomega matchers and does not typically need to be imported.
+See the docs for Gomega for documentation on the matchers
+
+http://onsi.github.io/gomega/
+*/
+
+package miter
+
+import "reflect"
+
+// HasIterators always returns false for Go versions before 1.23.
+func HasIterators() bool { return false }
+
+// IsIter always returns false for Go versions before 1.23 as there is no
+// iterator (function) pattern defined yet; see also:
+// https://tip.golang.org/blog/range-functions.
+func IsIter(i any) bool { return false }
+
+// IsSeq2 always returns false for Go versions before 1.23 as there is no
+// iterator (function) pattern defined yet; see also:
+// https://tip.golang.org/blog/range-functions.
+func IsSeq2(it any) bool { return false }
+
+// IterKVTypes always returns nil reflection types for Go versions before 1.23
+// as there is no iterator (function) pattern defined yet; see also:
+// https://tip.golang.org/blog/range-functions.
+func IterKVTypes(i any) (k, v reflect.Type) {
+	return
+}
+
+// IterateV never loops over what has been passed to it as an iterator for Go
+// versions before 1.23 as there is no iterator (function) pattern defined yet;
+// see also: https://tip.golang.org/blog/range-functions.
+func IterateV(it any, yield func(v reflect.Value) bool) {}
+
+// IterateKV never loops over what has been passed to it as an iterator for Go
+// versions before 1.23 as there is no iterator (function) pattern defined yet;
+// see also: https://tip.golang.org/blog/range-functions.
+func IterateKV(it any, yield func(k, v reflect.Value) bool) {}

--- a/matchers/iter_support_test.go
+++ b/matchers/iter_support_test.go
@@ -1,0 +1,55 @@
+package matchers_test
+
+var (
+	universalElements = []string{"foo", "bar", "baz"}
+	universalMap      = map[string]int{
+		"foo": 0,
+		"bar": 42,
+		"baz": 666,
+	}
+	fooElements = []string{"foo", "foo", "foo"}
+)
+
+func universalIter(yield func(string) bool) {
+	for _, element := range universalElements {
+		if !yield(element) {
+			return
+		}
+	}
+}
+
+func universalIter2(yield func(int, string) bool) {
+	for idx, element := range universalElements {
+		if !yield(idx, element) {
+			return
+		}
+	}
+}
+
+func emptyIter(yield func(string) bool) {}
+
+func emptyIter2(yield func(int, string) bool) {}
+
+func universalMapIter2(yield func(string, int) bool) {
+	for k, v := range universalMap {
+		if !yield(k, v) {
+			return
+		}
+	}
+}
+
+func fooIter(yield func(string) bool) {
+	for _, foo := range fooElements {
+		if !yield(foo) {
+			return
+		}
+	}
+}
+
+func fooIter2(yield func(int, string) bool) {
+	for idx, foo := range fooElements {
+		if !yield(idx, foo) {
+			return
+		}
+	}
+}

--- a/matchers/type_support.go
+++ b/matchers/type_support.go
@@ -15,6 +15,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+
+	"github.com/onsi/gomega/matchers/internal/miter"
 )
 
 type omegaMatcher interface {
@@ -152,6 +154,17 @@ func lengthOf(a interface{}) (int, bool) {
 	switch reflect.TypeOf(a).Kind() {
 	case reflect.Map, reflect.Array, reflect.String, reflect.Chan, reflect.Slice:
 		return reflect.ValueOf(a).Len(), true
+	case reflect.Func:
+		if !miter.IsIter(a) {
+			return 0, false
+		}
+		var l int
+		if miter.IsSeq2(a) {
+			miter.IterateKV(a, func(k, v reflect.Value) bool { l++; return true })
+		} else {
+			miter.IterateV(a, func(v reflect.Value) bool { l++; return true })
+		}
+		return l, true
 	default:
 		return 0, false
 	}


### PR DESCRIPTION
- new internal helper package for dealing with Go 1.23 iterators via reflection; for Go versions before 1.23 this package provides the same helper functions as stubs instead, shielding both the matchers code base as well as their tests from any code that otherwise would not build on pre-iterator versions. This allows to keep new iterator-related matcher code and associated tests inline, hopefully ensuring good maintainability.
- with the exception of ContainElements and ConsistOf, the other iterator-aware matchers do not need to go through producing all collection elements first in order to work on a slice of these elements. Instead, they directly work on the collection elements individually as their iterator produces them.
- BeEmpty: iter.Seq, iter.Seq2 w/ tests
- HaveLen: iter.Seq, iter.Seq2 w/ tests
- HaveEach: iter.Seq, iter.Seq2 w/ tests
- ContainElement: iter.Seq, iter.Seq2 w/ tests
- HaveExactElements: iter.Seq, iter.Seq2 w/ tests
- ContainElements: iter.Seq, iter.Seq2 w/ tests
- ConsistOf: iter.Seq, iter.Seq2 w/ test
- HaveKey: iter.Seq2 only w/ test
- HaveKeyWithValue: iter.Seq2 only w/ test
- updated documentation.