### PR TITLE
resolves onsi/gomega#696: make HaveField great on pointer receivers…

### DIFF
--- a/matchers/have_field.go
+++ b/matchers/have_field.go
@@ -40,7 +40,12 @@ func extractField(actual interface{}, field string, matchername string) (any, er
 			extractedValue = actualValue.Addr().MethodByName(strings.TrimSuffix(fields[0], "()"))
 		}
 		if extractedValue == (reflect.Value{}) {
-			return nil, missingFieldError(fmt.Sprintf("%s could not find method named '%s' in struct of type %T.", matchername, fields[0], actual))
+			ptr := reflect.New(actualValue.Type())
+			ptr.Elem().Set(actualValue)
+			extractedValue = ptr.MethodByName(strings.TrimSuffix(fields[0], "()"))
+			if extractedValue == (reflect.Value{}) {
+				return nil, missingFieldError(fmt.Sprintf("%s could not find method named '%s' in struct of type %T.", matchername, fields[0], actual))
+			}
 		}
 		t := extractedValue.Type()
 		if t.NumIn() != 0 || t.NumOut() != 1 {

--- a/matchers/have_field_test.go
+++ b/matchers/have_field_test.go
@@ -162,7 +162,7 @@ var _ = Describe("HaveField", func() {
 	})
 
 	Describe("receiver lookup", func() {
-		DescribeTable("(pointer) receiver lookup works",
+		DescribeTable("(pointer) receiver lookup on book pointer works",
 			func(field string, expected interface{}) {
 				Ω(&book).Should(HaveField(field, expected))
 			},
@@ -170,15 +170,15 @@ var _ = Describe("HaveField", func() {
 			Entry("pointer receiver", "PointerReceiverTitle()", "Les Miserables"),
 		)
 
+		It("correctly looks up a pointer receiver on a book value", func() {
+			Ω(book).Should(HaveField("PointerReceiverTitle()", "Les Miserables"))
+		})
+
 		It("correctly fails", func() {
 			matcher := HaveField("ReceiverTitle()", "Les Miserables")
 			answer := struct{}{}
 			Ω(matcher.Match(answer)).Error().Should(MatchError(
 				"HaveField could not find method named 'ReceiverTitle()' in struct of type struct {}."))
-
-			matcher = HaveField("PointerReceiverTitle()", "Les Miserables")
-			Ω(matcher.Match(book)).Error().Should(MatchError(
-				"HaveField could not find method named 'PointerReceiverTitle()' in struct of type matchers_test.Book."))
 		})
 	})
 


### PR DESCRIPTION
…given only a non-addressable value
- don't reject pointer receivers on non-addressable values anymore; instead, create a pointer value to the original value and then lookup the pointer receiver method.
- switches corresponding unit test from rejection to acceptance.