### PR TITLE
remove spurious "toolchain" from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/onsi/gomega
 
 go 1.22.0
 
-toolchain go1.22.10
-
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/onsi/ginkgo/v2 v2.22.2


### PR DESCRIPTION
Having go.mod specific a exact toolchain is not required and breaks some build systems.  The preference is to remove this allow Go to use the appropriate installed tooling.

Resolves: #818 