### PR TITLE
add To/ToNot/NotTo aliases for AsyncAssertion

### DIFF
--- a/internal/async_assertion.go
+++ b/internal/async_assertion.go
@@ -145,10 +145,22 @@ func (assertion *AsyncAssertion) Should(matcher types.GomegaMatcher, optionalDes
 	return assertion.match(matcher, true, optionalDescription...)
 }
 
+func (assertion *AsyncAssertion) To(matcher types.GomegaMatcher, optionalDescription ...any) bool {
+	return assertion.Should(matcher, optionalDescription...)
+}
+
 func (assertion *AsyncAssertion) ShouldNot(matcher types.GomegaMatcher, optionalDescription ...any) bool {
 	assertion.g.THelper()
 	vetOptionalDescription("Asynchronous assertion", optionalDescription...)
 	return assertion.match(matcher, false, optionalDescription...)
+}
+
+func (assertion *AsyncAssertion) ToNot(matcher types.GomegaMatcher, optionalDescription ...any) bool {
+	return assertion.ShouldNot(matcher, optionalDescription...)
+}
+
+func (assertion *AsyncAssertion) NotTo(matcher types.GomegaMatcher, optionalDescription ...any) bool {
+	return assertion.ShouldNot(matcher, optionalDescription...)
 }
 
 func (assertion *AsyncAssertion) buildDescription(optionalDescription ...any) string {

--- a/types/types.go
+++ b/types/types.go
@@ -70,6 +70,11 @@ type AsyncAssertion interface {
 	Should(matcher GomegaMatcher, optionalDescription ...any) bool
 	ShouldNot(matcher GomegaMatcher, optionalDescription ...any) bool
 
+	// equivalent to above
+	To(matcher GomegaMatcher, optionalDescription ...any) bool
+	ToNot(matcher GomegaMatcher, optionalDescription ...any) bool
+	NotTo(matcher GomegaMatcher, optionalDescription ...any) bool
+
 	WithOffset(offset int) AsyncAssertion
 	WithTimeout(interval time.Duration) AsyncAssertion
 	WithPolling(interval time.Duration) AsyncAssertion


### PR DESCRIPTION
fixes fixes https://github.com/onsi/gomega/issues/837

```
go mod edit -replace=github.com/onsi/gomega=github.com/grosser/gomega@grosser/to
```

```
Eventually(func() bool {
	err := getObj(hpa)
	return err == nil && hpa.Spec.MaxReplicas == expectedReplicas
}, "1s", "10ms").To(BeTrue())
```

even better would be `ExpectEventually ... To BeTrue`, but 🤷 