### PR TITLE
fix(async_assertion): use correct error in errors.As

### DIFF
--- a/internal/async_assertion.go
+++ b/internal/async_assertion.go
@@ -452,7 +452,7 @@ func (assertion *AsyncAssertion) match(matcher types.GomegaMatcher, desiredMatch
 				}
 			} else {
 				var fgErr formattedGomegaError
-				if errors.As(actualErr, &fgErr) {
+				if errors.As(matcherErr, &fgErr) {
 					message += fgErr.FormattedGomegaError() + "\n"
 				} else {
 					message += renderError(fmt.Sprintf("The matcher passed to %s returned the following error:", assertion.asyncType), matcherErr)


### PR DESCRIPTION
In AsyncAssertion.match, there is a confusion between
actualErr/matcherErr in one of the branches:

Before this commit, the code is:
```
if actualErr == nil
	if matcherErr == nil {
		// actualErr is nil, matcherErr is nil
		…
	} else {
		// actualErr is nil, matcherErr is non-nil
		var fgErr formattedGomegaError
		if errors.As(actualErr, &fgErr) {
			message += fgErr.FormattedGomegaError() + "\n"
		} else {
			message += renderError(fmt.Sprintf("The matcher passed to %s returned the following error:", assertion.asyncType), matcherErr)
		}
	}
} else {
	// actualErr is non-nil
	…
}
```

Calling `errors.As` on the nil `actualErr` looks like a mistake, this commit
changes it to `matcherErr` which is non-nil. This also matches the error
used in the second branch of the `if errors.As()` test.

This was reported by a static analysis tool.