### PR TITLE
gstruct: handle extra unexported fields

### DIFF
--- a/gstruct/types.go
+++ b/gstruct/types.go
@@ -12,4 +12,8 @@ const (
 	//considered by the identifier function. All members that map to a given key must still match successfully
 	//with the matcher that is provided for that key.
 	AllowDuplicates
+	//IgnoreUnexportedExtras tells the matcher to ignore extra unexported fields, rather than triggering a failure.
+	//it is not possible to check the value of unexported fields, so this option is only useful when you want to
+	//check every exported fields, but you don't care about extra unexported fields.
+	IgnoreUnexportedExtras
 )


### PR DESCRIPTION
solves https://github.com/onsi/gomega/issues/849

reflect is not able to extract unexported fields, which makes gstruct unable to work with unexported struct fields.
Sometimes, we may want to be able to ignore them, because it makes sense to test only the exported fields (testing the exported API of a package, not the internal details). It works with the IgnoreExtras option, but this is IMO too powerful, because now you cannot detect ExportedFields that are later added to the struct but not to the test. 

This PR is a proposition to allow unexported fields of a struct to be ignored via : 
- using gstruct.Ignore() (since this matcher does not need an actual value, it can be called without retrieving the real actual value)
- using the new IgnoreUnexportedExtras option, that will ignore extras only if they are unexported