### PR TITLE
support [] in IgnoringTopFunction function signatures

### DIFF
--- a/gleak/ignoring_top_function.go
+++ b/gleak/ignoring_top_function.go
@@ -25,17 +25,12 @@ import (
 // matches a goroutine where the name of the top function is "foo.bar" and the
 // goroutine's state starts with "running".
 func IgnoringTopFunction(topfname string) types.GomegaMatcher {
-	if lbrIndex := strings.LastIndex(topfname, "["); lbrIndex >= 0 {
-		// If the last ] is the last character, then there is a state,
-		// otherwise assume it was part of a type definition, eg "foo.bar(*implementation[...]).baz"
-		if rbrIndex := strings.LastIndex(topfname, "]"); rbrIndex == len(topfname)-1 {
-			expectedState := strings.Trim(topfname[lbrIndex:rbrIndex], "[]")
-			expectedTopFunction := strings.Trim(topfname[:lbrIndex], " ")
-
-			return &ignoringTopFunctionMatcher{
-				expectedTopFunction: expectedTopFunction,
-				expectedState:       expectedState,
-			}
+	if brIndex := strings.Index(topfname, " ["); brIndex >= 0 {
+		expectedState := strings.Trim(topfname[brIndex+1:], "[]")
+		expectedTopFunction := strings.Trim(topfname[:brIndex+1], " ")
+		return &ignoringTopFunctionMatcher{
+			expectedTopFunction: expectedTopFunction,
+			expectedState:       expectedState,
 		}
 	}
 	if strings.HasSuffix(topfname, "...") {

--- a/gleak/ignoring_top_function.go
+++ b/gleak/ignoring_top_function.go
@@ -25,12 +25,17 @@ import (
 // matches a goroutine where the name of the top function is "foo.bar" and the
 // goroutine's state starts with "running".
 func IgnoringTopFunction(topfname string) types.GomegaMatcher {
-	if brIndex := strings.Index(topfname, "["); brIndex >= 0 {
-		expectedState := strings.Trim(topfname[brIndex:], "[]")
-		expectedTopFunction := strings.Trim(topfname[:brIndex], " ")
-		return &ignoringTopFunctionMatcher{
-			expectedTopFunction: expectedTopFunction,
-			expectedState:       expectedState,
+	if lbrIndex := strings.LastIndex(topfname, "["); lbrIndex >= 0 {
+		// If the last ] is the last character, then there is a state,
+		// otherwise assume it was part of a type definition, eg "foo.bar(*implementation[...]).baz"
+		if rbrIndex := strings.LastIndex(topfname, "]"); rbrIndex == len(topfname)-1 {
+			expectedState := strings.Trim(topfname[lbrIndex:rbrIndex], "[]")
+			expectedTopFunction := strings.Trim(topfname[:lbrIndex], " ")
+
+			return &ignoringTopFunctionMatcher{
+				expectedTopFunction: expectedTopFunction,
+				expectedState:       expectedState,
+			}
 		}
 	}
 	if strings.HasSuffix(topfname, "...") {

--- a/gleak/ignoring_top_function_test.go
+++ b/gleak/ignoring_top_function_test.go
@@ -20,12 +20,31 @@ var _ = Describe("IgnoringTopFunction matcher", func() {
 		Expect(m.Match(Goroutine{
 			TopFunction: "main.main",
 		})).To(BeFalse())
+
+		m = IgnoringTopFunction("foo.bar(*implementation[...]).baz")
+		Expect(m.Match(Goroutine{
+			TopFunction: "foo.bar(*implementation[...]).baz",
+		})).To(BeTrue())
+		Expect(m.Match(Goroutine{
+			TopFunction: "main.main",
+		})).To(BeFalse())
 	})
 
 	It("matches a toplevel function by prefix", func() {
 		m := IgnoringTopFunction("foo...")
 		Expect(m.Match(Goroutine{
 			TopFunction: "foo.bar",
+		})).To(BeTrue())
+		Expect(m.Match(Goroutine{
+			TopFunction: "foo",
+		})).To(BeFalse())
+		Expect(m.Match(Goroutine{
+			TopFunction: "spanish.inquisition",
+		})).To(BeFalse())
+
+		m = IgnoringTopFunction("foo.bar(*implementation[...])...")
+		Expect(m.Match(Goroutine{
+			TopFunction: "foo.bar(*implementation[...]).baz",
 		})).To(BeTrue())
 		Expect(m.Match(Goroutine{
 			TopFunction: "foo",
@@ -43,6 +62,16 @@ var _ = Describe("IgnoringTopFunction matcher", func() {
 		})).To(BeTrue())
 		Expect(m.Match(Goroutine{
 			TopFunction: "foo.bar",
+			State:       "uneasy, anxious",
+		})).To(BeFalse())
+
+		m = IgnoringTopFunction("foo.bar(*implementation[...]) [worried]")
+		Expect(m.Match(Goroutine{
+			TopFunction: "foo.bar(*implementation[...])",
+			State:       "worried, stalled",
+		})).To(BeTrue())
+		Expect(m.Match(Goroutine{
+			TopFunction: "foo.bar(*implementation[...])",
 			State:       "uneasy, anxious",
 		})).To(BeFalse())
 	})


### PR DESCRIPTION
Solves https://github.com/onsi/gomega/issues/850

When parsing the `topofname` parameter in the `IgnoringTopFunction` function, the code now looks for the last set of brackets and verifies that it at the end of the string before setting expected state.

If brackets are found, but not at the end, the code continues and moves on to the "HasSuffix" logic.