### PR TITLE
chore: fix Go vet issue with Go 1.15

### DIFF
--- a/gmeasure/experiment.go
+++ b/gmeasure/experiment.go
@@ -469,9 +469,9 @@ func (e *Experiment) Sample(callback func(idx int), samplingConfig SamplingConfi
 		wg.Wait()
 	}()
 	if numParallel > 1 {
+		wg.Add(numParallel)
 		for worker := 0; worker < numParallel; worker++ {
 			go func() {
-				wg.Add(1)
 				for idx := range work {
 					callback(idx)
 				}


### PR DESCRIPTION
Go vet correctly found issue:
Error: gmeasure/experiment.go:474:11: WaitGroup.Add called from inside new goroutine