### PR TITLE
chore: apply fixes from Go modernize command

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -422,7 +422,7 @@ func formatSlice(v reflect.Value, indentation uint) string {
 	l := v.Len()
 	result := make([]string, l)
 	longest := 0
-	for i := 0; i < l; i++ {
+	for i := range l {
 		result[i] = formatValue(v.Index(i), indentation+1)
 		if len(result[i]) > longest {
 			longest = len(result[i])
@@ -462,7 +462,7 @@ func formatStruct(v reflect.Value, indentation uint) string {
 	l := v.NumField()
 	result := []string{}
 	longest := 0
-	for i := 0; i < l; i++ {
+	for i := range l {
 		structField := t.Field(i)
 		fieldEntry := v.Field(i)
 		representation := fmt.Sprintf("%s: %s", structField.Name, formatValue(fieldEntry, indentation+1))

--- a/gbytes/io_wrappers_test.go
+++ b/gbytes/io_wrappers_test.go
@@ -32,7 +32,7 @@ func (f FakeReader) Read(p []byte) (int, error) {
 		return 0, f.err
 	}
 
-	for i := 0; i < len(p); i++ {
+	for i := range p {
 		p[i] = 'a'
 	}
 

--- a/ghttp/handlers.go
+++ b/ghttp/handlers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -219,9 +220,7 @@ func (g GHTTPWithGomega) VerifyProtoRepresenting(expected protoiface.MessageV1) 
 }
 
 func copyHeader(src http.Header, dst http.Header) {
-	for key, value := range src {
-		dst[key] = value
-	}
+	maps.Copy(dst, src)
 }
 
 /*

--- a/ghttp/test_server.go
+++ b/ghttp/test_server.go
@@ -254,7 +254,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}()
 
 	if s.Writer != nil {
-		s.Writer.Write([]byte(fmt.Sprintf("GHTTP Received Request: %s - %s\n", req.Method, req.URL)))
+		s.Writer.Write(fmt.Appendf(nil, "GHTTP Received Request: %s - %s\n", req.Method, req.URL))
 	}
 
 	s.receivedRequests = append(s.receivedRequests, req)

--- a/gmeasure/experiment.go
+++ b/gmeasure/experiment.go
@@ -456,10 +456,7 @@ func (e *Experiment) Sample(callback func(idx int), samplingConfig SamplingConfi
 	if samplingConfig.N > 0 {
 		maxN = samplingConfig.N
 	}
-	numParallel := 1
-	if samplingConfig.NumParallel > numParallel {
-		numParallel = samplingConfig.NumParallel
-	}
+	numParallel := max(samplingConfig.NumParallel, 1)
 	minSamplingInterval := samplingConfig.MinSamplingInterval
 
 	work := make(chan int)

--- a/gmeasure/experiment_test.go
+++ b/gmeasure/experiment_test.go
@@ -180,7 +180,7 @@ var _ = Describe("Experiment", func() {
 
 		ints := func(n int) []int {
 			out := []int{}
-			for i := 0; i < n; i++ {
+			for i := range n {
 				out = append(out, i)
 			}
 			return out

--- a/matchers/have_key_matcher.go
+++ b/matchers/have_key_matcher.go
@@ -39,7 +39,7 @@ func (matcher *HaveKeyMatcher) Match(actual any) (success bool, err error) {
 	}
 
 	keys := reflect.ValueOf(actual).MapKeys()
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		success, err := keyMatcher.Match(keys[i].Interface())
 		if err != nil {
 			return false, fmt.Errorf("HaveKey's key matcher failed with:\n%s%s", format.Indent, err.Error())

--- a/matchers/have_key_with_value_matcher.go
+++ b/matchers/have_key_with_value_matcher.go
@@ -52,7 +52,7 @@ func (matcher *HaveKeyWithValueMatcher) Match(actual any) (success bool, err err
 	}
 
 	keys := reflect.ValueOf(actual).MapKeys()
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		success, err := keyMatcher.Match(keys[i].Interface())
 		if err != nil {
 			return false, fmt.Errorf("HaveKeyWithValue's key matcher failed with:\n%s%s", format.Indent, err.Error())

--- a/matchers/support/goraph/bipartitegraph/bipartitegraph_test.go
+++ b/matchers/support/goraph/bipartitegraph/bipartitegraph_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Bipartitegraph", func() {
 		)
 
 		BeforeEach(func() {
-			for i := 0; i < len(half); i++ {
+			for i := range half {
 				half[i] = i
 			}
 			discrete, _ = NewBipartiteGraph(half, half, discreteNeighbours)
@@ -152,7 +152,7 @@ var _ = Describe("Bipartitegraph", func() {
 		)
 
 		BeforeEach(func() {
-			for i := 0; i < len(half); i++ {
+			for i := range half {
 				half[i] = i
 			}
 			graph1, _ = NewBipartiteGraph(half, half, neighbours1)

--- a/matchers/support/goraph/edge/edge.go
+++ b/matchers/support/goraph/edge/edge.go
@@ -1,6 +1,9 @@
 package edge
 
-import . "github.com/onsi/gomega/matchers/support/goraph/node"
+import (
+	. "github.com/onsi/gomega/matchers/support/goraph/node"
+	"slices"
+)
 
 type Edge struct {
 	Node1 int
@@ -20,13 +23,7 @@ func (ec EdgeSet) Free(node Node) bool {
 }
 
 func (ec EdgeSet) Contains(edge Edge) bool {
-	for _, e := range ec {
-		if e == edge {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(ec, edge)
 }
 
 func (ec EdgeSet) FindByNodes(node1, node2 Node) (Edge, bool) {


### PR DESCRIPTION
The modernize command replaces old constructs with simpler, updated ones.

Command is:
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...