### PR TITLE
Add BeASlice and BeAnArray matchers

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -621,6 +621,18 @@ func BeADirectory() types.GomegaMatcher {
 	return &matchers.BeADirectoryMatcher{}
 }
 
+// BeASlice succeeds if actual is a value of slice type.
+// This is useful when actual has type any (interface{}) and you want to assert it is a slice.
+func BeASlice() types.GomegaMatcher {
+	return &matchers.BeASliceMatcher{}
+}
+
+// BeAnArray succeeds if actual is a value of array type.
+// This is useful when actual has type any (interface{}) and you want to assert it is an array.
+func BeAnArray() types.GomegaMatcher {
+	return &matchers.BeAnArrayMatcher{}
+}
+
 // HaveHTTPStatus succeeds if the Status or StatusCode field of an HTTP response matches.
 // Actual must be either a *http.Response or *httptest.ResponseRecorder.
 // Expected must be either an int or a string.

--- a/matchers/be_a_slice_matcher.go
+++ b/matchers/be_a_slice_matcher.go
@@ -1,0 +1,28 @@
+// untested sections: 1
+
+package matchers
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/gomega/format"
+)
+
+type BeASliceMatcher struct {
+}
+
+func (matcher *BeASliceMatcher) Match(actual any) (success bool, err error) {
+	if actual == nil {
+		return false, fmt.Errorf("BeASlice matcher expects a value, got nil")
+	}
+	return reflect.TypeOf(actual).Kind() == reflect.Slice, nil
+}
+
+func (matcher *BeASliceMatcher) FailureMessage(actual any) (message string) {
+	return format.Message(actual, "to be a slice")
+}
+
+func (matcher *BeASliceMatcher) NegatedFailureMessage(actual any) (message string) {
+	return format.Message(actual, "not to be a slice")
+}

--- a/matchers/be_a_slice_matcher_test.go
+++ b/matchers/be_a_slice_matcher_test.go
@@ -1,0 +1,52 @@
+package matchers_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/matchers"
+)
+
+var _ = Describe("BeASliceMatcher", func() {
+	When("passed a slice", func() {
+		It("should succeed", func() {
+			Expect([]int{1, 2, 3}).Should(BeASlice())
+			Expect([]string{}).Should(BeASlice())
+			Expect([]any{1, "two", 3.0}).Should(BeASlice())
+			Expect([]byte("hello")).Should(BeASlice())
+		})
+	})
+
+	When("passed a nil slice", func() {
+		It("should succeed", func() {
+			var s []int
+			Expect(s).Should(BeASlice())
+		})
+	})
+
+	When("passed a non-slice", func() {
+		It("should fail", func() {
+			Expect("hello").ShouldNot(BeASlice())
+			Expect(42).ShouldNot(BeASlice())
+			Expect(true).ShouldNot(BeASlice())
+			Expect(map[string]int{"a": 1}).ShouldNot(BeASlice())
+			Expect([3]int{1, 2, 3}).ShouldNot(BeASlice())
+			Expect(struct{}{}).ShouldNot(BeASlice())
+		})
+	})
+
+	When("passed nil", func() {
+		It("should error", func() {
+			success, err := (&BeASliceMatcher{}).Match(nil)
+			Expect(success).Should(BeFalse())
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+
+	It("should produce appropriate failure messages", func() {
+		matcher := &BeASliceMatcher{}
+
+		matcher.Match("hello")
+		Expect(matcher.FailureMessage("hello")).Should(ContainSubstring("to be a slice"))
+		Expect(matcher.NegatedFailureMessage("hello")).Should(ContainSubstring("not to be a slice"))
+	})
+})

--- a/matchers/be_an_array_matcher.go
+++ b/matchers/be_an_array_matcher.go
@@ -1,0 +1,28 @@
+// untested sections: 1
+
+package matchers
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/gomega/format"
+)
+
+type BeAnArrayMatcher struct {
+}
+
+func (matcher *BeAnArrayMatcher) Match(actual any) (success bool, err error) {
+	if actual == nil {
+		return false, fmt.Errorf("BeAnArray matcher expects a value, got nil")
+	}
+	return reflect.TypeOf(actual).Kind() == reflect.Array, nil
+}
+
+func (matcher *BeAnArrayMatcher) FailureMessage(actual any) (message string) {
+	return format.Message(actual, "to be an array")
+}
+
+func (matcher *BeAnArrayMatcher) NegatedFailureMessage(actual any) (message string) {
+	return format.Message(actual, "not to be an array")
+}

--- a/matchers/be_an_array_matcher_test.go
+++ b/matchers/be_an_array_matcher_test.go
@@ -1,0 +1,45 @@
+package matchers_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/matchers"
+)
+
+var _ = Describe("BeAnArrayMatcher", func() {
+	When("passed an array", func() {
+		It("should succeed", func() {
+			Expect([3]int{1, 2, 3}).Should(BeAnArray())
+			Expect([0]string{}).Should(BeAnArray())
+			Expect([2]any{1, "two"}).Should(BeAnArray())
+			Expect([4]byte{1, 2, 3, 4}).Should(BeAnArray())
+		})
+	})
+
+	When("passed a non-array", func() {
+		It("should fail", func() {
+			Expect("hello").ShouldNot(BeAnArray())
+			Expect(42).ShouldNot(BeAnArray())
+			Expect(true).ShouldNot(BeAnArray())
+			Expect(map[string]int{"a": 1}).ShouldNot(BeAnArray())
+			Expect([]int{1, 2, 3}).ShouldNot(BeAnArray())
+			Expect(struct{}{}).ShouldNot(BeAnArray())
+		})
+	})
+
+	When("passed nil", func() {
+		It("should error", func() {
+			success, err := (&BeAnArrayMatcher{}).Match(nil)
+			Expect(success).Should(BeFalse())
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+
+	It("should produce appropriate failure messages", func() {
+		matcher := &BeAnArrayMatcher{}
+
+		matcher.Match("hello")
+		Expect(matcher.FailureMessage("hello")).Should(ContainSubstring("to be an array"))
+		Expect(matcher.NegatedFailureMessage("hello")).Should(ContainSubstring("not to be an array"))
+	})
+})


### PR DESCRIPTION
## Summary

Implements `BeASlice()` and `BeAnArray()` matchers as requested in #584.

These matchers enable type assertions for slice and array types when working with `interface{}` values:

- **BeASlice()**: Succeeds if actual is a slice type (`[]T`)
- **BeAnArray()**: Succeeds if actual is an array type (`[N]T`)

## Examples

```go
var data any = []int{1, 2, 3}
Expect(data).Should(BeASlice())

var arr any = [3]int{1, 2, 3}
Expect(arr).Should(BeAnArray())

Expect("hello").ShouldNot(BeASlice())  // string is not a slice

```

## Implementation

- Added BeASliceMatcher and BeAnArrayMatcher structs in matchers package
- Added constructor functions BeASlice() and BeAnArray() in root matchers.go
- Full test coverage including:
  - Multiple slice/array element types
  - Nil slice handling
  - Type validation (error on nil literal)
  - Failure message verification
  - Negation tests


## Testing
All 524 matchers tests pass
go vet ./... passes with no warnings
9 new specs covering both matchers