### PR TITLE
feat: devcontainer configuration for easier Gomega contribution

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+{
+    "name": "gomega",
+    "portsAttributes": {
+        "4000": {
+            "label": "Github pages documentation",
+            "protocol": "http"
+        },
+        "6060": {
+            "label": "Gomega package documentation",
+            "onAutoForward": "silent",
+            "protocol": "http"
+        }
+    },
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+    "features": {
+        "ghcr.io/thediveo/devcontainer-features/local-pkgsite:0": {},
+        "ghcr.io/thediveo/devcontainer-features/lazygit:0": {},
+        "ghcr.io/rails/devcontainer/features/ruby:2": {
+            "version": "3"
+        }
+    },
+    "remoteEnv": {
+        "GOPATH": "/home/vscode/go",
+        "PATH": "/home/vscode/.local/bin:/home/vscode/go/bin:/go/bin:/usr/local/go/bin:/home/vscode/.local/share/mise/installs/ruby/3/bin:${localEnv:PATH}",
+        "RUBYOPT": "-rbigdecimal"
+    },
+    "postCreateCommand": {
+        "finalizing-devcontainer": "sudo .devcontainer/install.sh",
+        "off-rails": "cd docs && bundle install && gem install bigdecimal"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "dnut.rewrap-revived",
+                "mhutchie.git-graph"
+            ]
+        }
+    }
+}

--- a/.devcontainer/first-run-notice.ansi
+++ b/.devcontainer/first-run-notice.ansi
@@ -1,0 +1,2 @@
+* [1mgomegatest[22m runs the full test suite.
+* [1mserve-docs[22m serves Gomega Github pages on http://127.0.0.1:4000/gomega.

--- a/.devcontainer/gomegatest
+++ b/.devcontainer/gomegatest
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+go run github.com/onsi/ginkgo/v2/ginkgo \
+    -r --randomize-all --randomize-suites \
+    --race --trace \
+    --fail-on-pending --keep-going --label-filter="!network"

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+echo "finalizing devcontainer setup.."
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'script must be run as root.'
+    exit 1
+fi
+
+WSCSSHARED="/workspaces/.codespaces/shared"
+mkdir -p "${WSCSSHARED}"
+cp .devcontainer/first-run-notice.ansi "${WSCSSHARED}/first-run-notice.txt"
+cp .devcontainer/gomegatest .devcontainer/serve-docs /usr/local/bin
+
+echo "done."

--- a/.devcontainer/serve-docs
+++ b/.devcontainer/serve-docs
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+PWD_REAL="$(pwd)"
+case "${PWD_REAL}" in
+    /workspaces/*)
+        ;;
+    *)
+        echo "not inside a devcontainer workspace: ${PWD_REAL}"
+        exit 1
+        ;;
+esac
+WORKSPACE_ROOT="$(echo "${PWD_REAL}" | cut -d/ -f1-3)"
+DOCS_DIR="${WORKSPACE_ROOT}/docs"
+if [ ! -d "${DOCS_DIR}" ]; then
+    echo "docs directory ${DOCS_DIR} not found"
+    exit 1
+fi
+cd "$DOCS_DIR"
+exec bundle exec jekyll serve "$@"


### PR DESCRIPTION
This adds an (refined version) for optional development container configuration to the Gomega repository:
- uses mcr.microsoft.com/devcontainers/base:ubuntu-24.04 as the base image.
- installs Go from upstream, as well as lazygit for all chores git.
- installs Ruby and then does a "bundle install" inside the docs directory, working around a problem with the missing bigdecimal dependency on newer Ruby installations.
- installs local pkgsite feature that services Ginkgo's godoc on local container port 6060.
- provides convenience commands:
  - `gomegatest` runs the same Ginkgo-based full testing as the test workflow does.
  - `serve-docs` runs `bundle exec jekyll serve` inside the `docs/` directory, serving on local container port 4000.
- sets up a first-run-notice that explain the `gomegatest` and `serve-docs` commands.

To use with VSCode and the "dev containers" extension installed: command => "Dev Containers: Open Folder in Container...". This should automatically pick up the devcontainer configuration from `.devcontainer/devcontainer.json` and build the dev container according to spec (which will initially take a while); afterwards, the dev container is started and its configuration completed, wait for the bundler installation to finish.