### PR TITLE
fix(MatchError): match error values only via errors.Is

### DIFF
--- a/matchers/match_error_matcher.go
+++ b/matchers/match_error_matcher.go
@@ -29,17 +29,10 @@ func (matcher *MatchErrorMatcher) Match(actual any) (success bool, err error) {
 	expected := matcher.Expected
 
 	if isError(expected) {
-		// first try the built-in errors.Is
-		if errors.Is(actualErr, expected.(error)) {
-			return true, nil
-		}
-		// if not, try DeepEqual along the error chain
-		for unwrapped := actualErr; unwrapped != nil; unwrapped = errors.Unwrap(unwrapped) {
-			if reflect.DeepEqual(unwrapped, expected) {
-				return true, nil
-			}
-		}
-		return false, nil
+		// Only errors.Is — do not DeepEqual error values. Two independently
+		// constructed errors.New("same text") are DeepEqual but not the same
+		// sentinel, so DeepEqual would hide missing errors.Is wiring (#876).
+		return errors.Is(actualErr, expected.(error)), nil
 	}
 
 	if isString(expected) {

--- a/matchers/match_error_matcher_test.go
+++ b/matchers/match_error_matcher_test.go
@@ -27,15 +27,15 @@ func (t *ComplexError) Error() string {
 var _ = Describe("MatchErrorMatcher", func() {
 	Context("When asserting against an error", func() {
 		When("passed an error", func() {
-			It("should succeed when errors are deeply equal", func() {
+			It("should succeed when errors.Is matches (not merely equal text)", func() {
 				err := errors.New("an error")
-				fmtErr := fmt.Errorf("an error")
 				customErr := CustomError{}
 
-				Expect(err).Should(MatchError(errors.New("an error")))
+				// Same sentinel instance / value that implements equality via errors.Is.
+				Expect(err).Should(MatchError(err))
+				Expect(err).ShouldNot(MatchError(errors.New("an error"))) // different instance, same text (#876)
 				Expect(err).ShouldNot(MatchError(errors.New("another error")))
 
-				Expect(fmtErr).Should(MatchError(errors.New("an error")))
 				Expect(customErr).Should(MatchError(CustomError{}))
 			})
 
@@ -46,10 +46,11 @@ var _ = Describe("MatchErrorMatcher", func() {
 				Expect(outerErr).Should(MatchError(innerErr))
 			})
 
-			It("uses deep equality with unwrapped errors", func() {
+			It("does not treat independently constructed equal values as the same sentinel", func() {
+				// #876: DeepEqual on unwrapped errors hid missing errors.Is wiring.
 				innerErr := &ComplexError{Key: "abc"}
 				outerErr := fmt.Errorf("outer error wrapping: %w", &ComplexError{Key: "abc"})
-				Expect(outerErr).To(MatchError(innerErr))
+				Expect(outerErr).NotTo(MatchError(innerErr))
 			})
 		})
 


### PR DESCRIPTION
## Summary

`MatchError(err)` previously fell back to `reflect.DeepEqual` along the unwrap chain. Two independently constructed `errors.New(\"same text\")` values are DeepEqual but not the same sentinel, so tests could pass even when production code failed `errors.Is` (#876).

## Fix

When the expected argument is an `error`, match only with `errors.Is`. String and matcher forms are unchanged.

## Tests

Updated MatchError matcher specs for sentinel-only semantics.

```text
go test ./matchers -count=1
# ok
```

Fixes #876