### PR TITLE
Add gomock adaptor extension for using Gomega matchers with gomock

### DIFF
--- a/extensions/gomockadaptor/gomockadaptor.go
+++ b/extensions/gomockadaptor/gomockadaptor.go
@@ -1,0 +1,64 @@
+/*
+package gomockadaptor lets you use Gomega matchers as gomock argument matchers.
+
+gomock (both github.com/golang/mock/gomock and go.uber.org/mock/gomock) accepts
+any value implementing its Matcher interface:
+
+	type Matcher interface {
+		Matches(x any) bool
+		String() string
+	}
+
+Match wraps a Gomega matcher in a value that satisfies that interface, so the
+full set of Gomega matchers becomes available when setting up gomock expectations:
+
+	mock.EXPECT().Send(gomockadaptor.Match(gomega.HaveLen(3)))
+	mock.EXPECT().Store(gomockadaptor.Match(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+		"Name": gomega.Equal("Jane"),
+	})))
+
+The adaptor deliberately lives outside Gomega's core DSL and does not import
+gomock, so it adds no dependencies to Gomega.
+*/
+package gomockadaptor
+
+import "github.com/onsi/gomega/types"
+
+// Adaptor wraps a Gomega matcher so it satisfies gomock's Matcher interface.
+// Use Match to build one.
+type Adaptor struct {
+	matcher types.GomegaMatcher
+	// failureMessage holds the message from the most recent failed match so
+	// String can explain why an argument did not match.
+	failureMessage string
+}
+
+// Match returns an Adaptor that wraps the given Gomega matcher. The returned
+// value implements gomock's Matcher interface and can be passed directly to a
+// gomock expectation.
+func Match(matcher types.GomegaMatcher) *Adaptor {
+	return &Adaptor{matcher: matcher}
+}
+
+// Matches reports whether x satisfies the wrapped Gomega matcher. A matcher
+// that errors is treated as a non-match, with the error surfaced through
+// String. This satisfies gomock's Matcher interface.
+func (a *Adaptor) Matches(x any) bool {
+	a.failureMessage = ""
+	success, err := a.matcher.Match(x)
+	if err != nil {
+		a.failureMessage = err.Error()
+		return false
+	}
+	if !success {
+		a.failureMessage = a.matcher.FailureMessage(x)
+	}
+	return success
+}
+
+// String returns the failure message from the most recent failed match, so
+// gomock can include it in its report. This satisfies gomock's Matcher
+// interface.
+func (a *Adaptor) String() string {
+	return a.failureMessage
+}

--- a/extensions/gomockadaptor/gomockadaptor_suite_test.go
+++ b/extensions/gomockadaptor/gomockadaptor_suite_test.go
@@ -1,0 +1,13 @@
+package gomockadaptor_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGomockadaptor(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gomockadaptor Suite")
+}

--- a/extensions/gomockadaptor/gomockadaptor_test.go
+++ b/extensions/gomockadaptor/gomockadaptor_test.go
@@ -1,0 +1,64 @@
+package gomockadaptor_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/extensions/gomockadaptor"
+	"github.com/onsi/gomega/types"
+)
+
+// gomockMatcher mirrors gomock's Matcher interface so we can assert, without
+// depending on gomock, that an Adaptor can be used wherever one is expected.
+type gomockMatcher interface {
+	Matches(x any) bool
+	String() string
+}
+
+var _ gomockMatcher = gomockadaptor.Match(Equal(1))
+
+// erroringMatcher is a GomegaMatcher whose Match always returns an error.
+type erroringMatcher struct{}
+
+func (erroringMatcher) Match(actual any) (bool, error) {
+	return false, errors.New("boom")
+}
+func (erroringMatcher) FailureMessage(actual any) string        { return "should not be used" }
+func (erroringMatcher) NegatedFailureMessage(actual any) string { return "should not be used" }
+
+var _ types.GomegaMatcher = erroringMatcher{}
+
+var _ = Describe("Gomockadaptor", func() {
+	It("reports a match when the wrapped matcher succeeds", func() {
+		adaptor := gomockadaptor.Match(Equal(3))
+		Expect(adaptor.Matches(3)).To(BeTrue())
+		Expect(adaptor.String()).To(BeEmpty())
+	})
+
+	It("reports no match when the wrapped matcher fails, and surfaces the failure message", func() {
+		adaptor := gomockadaptor.Match(Equal(3))
+		Expect(adaptor.Matches(4)).To(BeFalse())
+		Expect(adaptor.String()).To(ContainSubstring("to equal"))
+	})
+
+	It("treats a matcher error as a non-match and surfaces the error", func() {
+		adaptor := gomockadaptor.Match(erroringMatcher{})
+		Expect(adaptor.Matches("anything")).To(BeFalse())
+		Expect(adaptor.String()).To(Equal("boom"))
+	})
+
+	It("clears the failure message between calls", func() {
+		adaptor := gomockadaptor.Match(Equal(3))
+		Expect(adaptor.Matches(4)).To(BeFalse())
+		Expect(adaptor.String()).NotTo(BeEmpty())
+		Expect(adaptor.Matches(3)).To(BeTrue())
+		Expect(adaptor.String()).To(BeEmpty())
+	})
+
+	It("works with composed matchers", func() {
+		adaptor := gomockadaptor.Match(HaveLen(2))
+		Expect(adaptor.Matches([]string{"a", "b"})).To(BeTrue())
+		Expect(adaptor.Matches([]string{"a"})).To(BeFalse())
+	})
+})


### PR DESCRIPTION
Picks up #451. @onsi, on that issue you mentioned you'd be happy to pull in a gomock adapter as an extension package, so here it is.

It adds `extensions/gomockadaptor`. `Match` wraps a Gomega matcher in a value that satisfies gomock's `Matcher` interface (`Matches(any) bool` plus `String() string`), so any Gomega matcher can be used as a gomock argument matcher:

```go
mock.EXPECT().Send(gomockadaptor.Match(HaveLen(3)))
```

On a failed match it captures the matcher's `FailureMessage` and returns it from `String()`, so gomock's report explains why the argument didn't match. The package doesn't import gomock (it relies on structural typing), so it adds no dependencies to Gomega. The tests assert the adaptor satisfies the gomock Matcher shape via a local interface, so they stay dependency free too.

I kept it out of the core DSL like you suggested. Happy to rename or move the package if you'd prefer a different home for it.
